### PR TITLE
fix(theme): force text contrast on selection

### DIFF
--- a/themes/angular-theme/lib/core/theming/_all-theme.scss
+++ b/themes/angular-theme/lib/core/theming/_all-theme.scss
@@ -38,6 +38,7 @@
 
     *::selection {
       background: mat-color($background, selected-text);
+      color: mat-color($foreground, text);
     }
   }
 


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/371041/114526416-40e08880-9c47-11eb-9152-e363069093ca.png)

after:

![image](https://user-images.githubusercontent.com/371041/114526511-59e93980-9c47-11eb-8e10-f47a8ffbfeac.png)
