### PR TITLE
fix(icon): gradient without autoprefixer

### DIFF
--- a/themes/angular-theme/lib/icon/_icon-theme.scss
+++ b/themes/angular-theme/lib/icon/_icon-theme.scss
@@ -7,6 +7,7 @@
   .mat-icon[color=gradient] {
     background: mat-color($uxg-gradient, vertical);
     background-clip: text;
+    -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
   }
 


### PR DESCRIPTION
Currently when you use SASS theme and your app does not run autoprefixer, you end up with gradient icons like this:

![image](https://user-images.githubusercontent.com/371041/115026671-100c8780-9ec3-11eb-9d0d-24b5c29db954.png)

It's already happening on some StackBlitz examples.
Adding prefix manually ensure user will have correct rendering even if he is not using any auto-prefixing tool.