### PR TITLE
feat(global-nav): add optional shortName

### DIFF
--- a/apps/angular-test-app/src/app/components/global-nav-demo/global-nav-demo.component.html
+++ b/apps/angular-test-app/src/app/components/global-nav-demo/global-nav-demo.component.html
@@ -1,6 +1,7 @@
 <div class="demo-container">
   <uxg-global-nav
     [appName]="appName"
+    [shortName]="shortName"
     [navigationNodes]="demoAppList"
     [appContent]="appContent"
     [navbarAction]="navbarAction"

--- a/apps/angular-test-app/src/app/components/global-nav-demo/global-nav-demo.component.ts
+++ b/apps/angular-test-app/src/app/components/global-nav-demo/global-nav-demo.component.ts
@@ -11,6 +11,7 @@ import { NavigationNode } from '@finastra/angular-components/global-nav';
 })
 export class GlobalNavDemoComponent {
   appName = 'Global Nav Demo';
+  shortName = 'gbd';
 
   demoAppList: NavigationNode[] = [
     {

--- a/libs/angular-components/global-nav/src/components/sidenav/sidenav.component.ts
+++ b/libs/angular-components/global-nav/src/components/sidenav/sidenav.component.ts
@@ -20,6 +20,7 @@ import { EventEmitter } from '@angular/core';
 })
 export class SidenavComponent implements OnInit, OnChanges {
   @Input() appName!: string;
+  @Input() shortName!: string;
   @Input() navigationNodes!: NavigationNode[];
   @Input() activeRoute!: string;
 
@@ -33,7 +34,7 @@ export class SidenavComponent implements OnInit, OnChanges {
   constructor(@Inject(forwardRef(() => MatSidenav)) private _host: MatSidenav, private cd: ChangeDetectorRef) {}
 
   ngOnInit() {
-    this.iconName = this.getIconName(this.appName);
+    this.iconName = this.shortName && this.shortName.length > 0 ? this.shortName : this.getIconName(this.appName);
     this._host.openedChange.subscribe(() => {
       this.currentNodes = this.navigationNodes;
       this.cd.markForCheck();
@@ -49,7 +50,7 @@ export class SidenavComponent implements OnInit, OnChanges {
   private getIconName(name: string) {
     if (!name) return name;
     const words = name.replace('-', ' ').split(' ');
-    if (words && words.length === 1) return name;
+    if (words && words.length === 1) return name.substring(0, 3);
     return !words
       ? ''
       : words

--- a/libs/angular-components/global-nav/src/global-nav.component.html
+++ b/libs/angular-components/global-nav/src/global-nav.component.html
@@ -2,6 +2,7 @@
   <mat-sidenav #globalNavDrawer mode="over">
     <uxg-sidenav
       [appName]="appName"
+      [shortName]="shortName"
       [navigationNodes]="navigationNodes"
       [activeRoute]="activeRoute"
       (nodeChosen)="nodeChosen.emit($event)"

--- a/libs/angular-components/global-nav/src/global-nav.component.ts
+++ b/libs/angular-components/global-nav/src/global-nav.component.ts
@@ -24,6 +24,7 @@ import { ReplaySubject } from 'rxjs';
 })
 export class GlobalNavComponent implements OnInit, OnDestroy {
   @Input() appName!: string;
+  @Input() shortName!: string;
   @Input() navigationNodes!: NavigationNode[];
   @Input() activeRoute!: string;
   @Input() currentNode!: NavigationNode;


### PR DESCRIPTION
New feature for the global-nav 🥳

* add _shortName_ input to force the _iconName_ in the product card component, but why ?? For example Malauzai short name is MZL.
* add a limit for long _iconName_ without whitespace.