### PR TITLE
refactor(theme): remove angular material @use trailing slash

### DIFF
--- a/themes/angular-theme/lib/avatar/_avatar-theme.scss
+++ b/themes/angular-theme/lib/avatar/_avatar-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '../core/theming/palette' as fds;
 
 @mixin multiple-backgrounds($backgrounds...) {

--- a/themes/angular-theme/lib/badge/_badge-theme.scss
+++ b/themes/angular-theme/lib/badge/_badge-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '../core/theming/palette';
 
 @mixin uxg-badge-color($color-name, $color) {

--- a/themes/angular-theme/lib/breadcrumb/_breadcrumb-theme.scss
+++ b/themes/angular-theme/lib/breadcrumb/_breadcrumb-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
   $primary: map.get($theme, primary);

--- a/themes/angular-theme/lib/button-toggle/_button-toggle-theme.scss
+++ b/themes/angular-theme/lib/button-toggle/_button-toggle-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '../core/theming/palette' as fds;
 
 @mixin theme($theme) {

--- a/themes/angular-theme/lib/button/_button-theme.scss
+++ b/themes/angular-theme/lib/button/_button-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '../core/theming/palette' as palette;
 
 @mixin theme($theme) {

--- a/themes/angular-theme/lib/card/_card-theme.scss
+++ b/themes/angular-theme/lib/card/_card-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '../core/theming/palette' as palette;
 
 @function str-replace($string, $search, $replace: '') {

--- a/themes/angular-theme/lib/chips/_chips-theme.scss
+++ b/themes/angular-theme/lib/chips/_chips-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '../core/theming/palette';
 
 @mixin theme($theme) {

--- a/themes/angular-theme/lib/core/theming/_palette.scss
+++ b/themes/angular-theme/lib/core/theming/_palette.scss
@@ -1,6 +1,6 @@
 @use 'sass:meta';
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '~@angular/material/core/theming/palette' as matPalette;
 
 @function get-color-from-palette($palette, $hue: default, $opacity: null) {

--- a/themes/angular-theme/lib/core/theming/_theming.scss
+++ b/themes/angular-theme/lib/core/theming/_theming.scss
@@ -1,5 +1,5 @@
 /* stylelint-disable no-invalid-position-at-import-rule */
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use './palette' as uxg-palette;
 
 $uxg-primary: mat.define-palette(uxg-palette.$uxg-violet, 500, 100, 900);

--- a/themes/angular-theme/lib/expansion/_expansion-theme.scss
+++ b/themes/angular-theme/lib/expansion/_expansion-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '../core/theming/palette';
 
 @mixin theme($theme) {

--- a/themes/angular-theme/lib/form-field/_form-field-theme.scss
+++ b/themes/angular-theme/lib/form-field/_form-field-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '../core/theming/palette';
 
 @mixin theme($theme) {

--- a/themes/angular-theme/lib/list/_list-theme.scss
+++ b/themes/angular-theme/lib/list/_list-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '../core/theming/palette';
 
 @mixin theme($theme) {

--- a/themes/angular-theme/lib/table/_table-theme.scss
+++ b/themes/angular-theme/lib/table/_table-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material/' as mat;
+@use '~@angular/material' as mat;
 @use '../core/theming/palette';
 
 @mixin theme($theme) {


### PR DESCRIPTION
Remove trailing slash in @use statement of angular-material.
Looks like it's not appreciated by Stackblitz.