### PR TITLE
fix(fds): change typo names with dash

### DIFF
--- a/apps/fds-test-app/src/index.html
+++ b/apps/fds-test-app/src/index.html
@@ -142,18 +142,18 @@
     </div>
 
     <div class="typography">
-      <h1 class="my-headline1">Headline 1</h1>
-      <h2 class="fds-headline2">Headline 2</h2>
-      <h3 class="fds-headline3">Headline 3</h3>
-      <h4 class="fds-headline4">Headline 4</h4>
-      <h5 class="fds-headline5">Headline 5</h5>
-      <h6 class="fds-headline6">Headline 6</h6>
-      <p class="fds-subtitle1">subtitle 1</p>
-      <p class="fds-subtitle2">subtitle 2</p>
-      <p class="fds-subtitle3">subtitle 3</p>
-      <p class="fds-body1">body 1</p>
-      <p class="fds-body2">body 2</p>
-      <p class="fds-body3">body 3</p>
+      <h1 class="my-headline-1">Headline 1</h1>
+      <h2 class="fds-headline-2">Headline 2</h2>
+      <h3 class="fds-headline-3">Headline 3</h3>
+      <h4 class="fds-headline-4">Headline 4</h4>
+      <h5 class="fds-headline-5">Headline 5</h5>
+      <h6 class="fds-headline-6">Headline 6</h6>
+      <p class="fds-subtitle-1">subtitle 1</p>
+      <p class="fds-subtitle-2">subtitle 2</p>
+      <p class="fds-subtitle-3">subtitle 3</p>
+      <p class="fds-body-1">body 1</p>
+      <p class="fds-body-2">body 2</p>
+      <p class="fds-body-3">body 3</p>
       <p class="fds-button">button</p>
       <p class="fds-caption">caption</p>
       <p class="fds-overline">overline</p>

--- a/apps/fds-test-app/src/styles.scss
+++ b/apps/fds-test-app/src/styles.scss
@@ -19,9 +19,9 @@ body {
     border-radius: 50%;
 }
 
-// .my-headline1 {
-//     @include fds.typography(headline1);
-// }
+.my-headline-1 {
+    @include fds.typography(headline-1);
+}
 
 // @media (prefers-color-scheme: dark) {
 //     @include fds.use-dark-theme();

--- a/themes/fds-theme/typography/README.mdx
+++ b/themes/fds-theme/typography/README.mdx
@@ -44,8 +44,8 @@ Where `$style` is any of the [available text styles](#available-text-styles).
 
 ### Available text styles
 
-| Text style  | font-family | font-size |
-| ----------- | ----------- | --------: |
+| Text style   | font-family | font-size |
+| ------------ | ----------- | --------: |
 | `headline-1` | Spartan     |      51px |
 | `headline-2` | Spartan     |      41px |
 | `headline-3` | Spartan     |      28px |

--- a/themes/fds-theme/typography/README.mdx
+++ b/themes/fds-theme/typography/README.mdx
@@ -8,18 +8,18 @@
 | -------------------------- | ----------- | --------: |
 | --fds-font-family          | Roboto      |           |
 | --fds-headline-font-family | Spartan     |           |
-| --fds-headline1            | Spartan     |      51px |
-| --fds-headline2            | Spartan     |      41px |
-| --fds-headline3            | Spartan     |      28px |
-| --fds-headline4            | Spartan     |      21px |
-| --fds-headline5            | Spartan     |      16px |
-| --fds-headline6            | Spartan     |      13px |
-| --fds-subtitle1            | Roboto      |      16px |
-| --fds-subtitle2            | Roboto      |      14px |
-| --fds-subtitle3            | Roboto      |      12px |
-| --fds-body1                | Roboto      |      16px |
-| --fds-body2                | Roboto      |      14px |
-| --fds-body3                | Roboto      |      12px |
+| --fds-headline-1           | Spartan     |      51px |
+| --fds-headline-2           | Spartan     |      41px |
+| --fds-headline-3           | Spartan     |      28px |
+| --fds-headline-4           | Spartan     |      21px |
+| --fds-headline-5           | Spartan     |      16px |
+| --fds-headline-6           | Spartan     |      13px |
+| --fds-subtitle-1           | Roboto      |      16px |
+| --fds-subtitle-2           | Roboto      |      14px |
+| --fds-subtitle-3           | Roboto      |      12px |
+| --fds-body-1               | Roboto      |      16px |
+| --fds-body-2               | Roboto      |      14px |
+| --fds-body-3               | Roboto      |      12px |
 | --fds-button               | Roboto      |      14px |
 | --fds-caption              | Roboto      |      12px |
 | --fds-overline             | Roboto      |      10px |
@@ -38,7 +38,7 @@ Where `$style` is any of the [available text styles](#available-text-styles).
 @use '@finastra/fds-theme' as fds;
 
 .my-component-subtitle {
-  @include fds.typography(subtitle2);
+  @include fds.typography(subtitle-2);
 }
 ```
 
@@ -46,21 +46,21 @@ Where `$style` is any of the [available text styles](#available-text-styles).
 
 | Text style  | font-family | font-size |
 | ----------- | ----------- | --------: |
-| `headline1` | Spartan     |      51px |
-| `headline2` | Spartan     |      41px |
-| `headline3` | Spartan     |      28px |
-| `headline4` | Spartan     |      21px |
-| `headline5` | Spartan     |      16px |
-| `headline6` | Spartan     |      13px |
-| `subtitle1` | Roboto      |      16px |
-| `subtitle2` | Roboto      |      14px |
-| `subtitle3` | Roboto      |      12px |
-| `body1`     | Roboto      |      16px |
-| `body2`     | Roboto      |      14px |
-| `body3`     | Roboto      |      12px |
-| `button`    | Roboto      |      14px |
-| `caption`   | Roboto      |      12px |
-| `overline`  | Roboto      |      10px |
+| `headline-1` | Spartan     |      51px |
+| `headline-2` | Spartan     |      41px |
+| `headline-3` | Spartan     |      28px |
+| `headline-4` | Spartan     |      21px |
+| `headline-5` | Spartan     |      16px |
+| `headline-6` | Spartan     |      13px |
+| `subtitle-1` | Roboto      |      16px |
+| `subtitle-2` | Roboto      |      14px |
+| `subtitle-3` | Roboto      |      12px |
+| `body-1`     | Roboto      |      16px |
+| `body-2`     | Roboto      |      14px |
+| `body-3`     | Roboto      |      12px |
+| `button`     | Roboto      |      14px |
+| `caption`    | Roboto      |      12px |
+| `overline`   | Roboto      |      10px |
 
 ## Helper classes
 
@@ -73,5 +73,5 @@ Before being able to use typography helper classes, you will have to include the
 ### Example
 
 ```HTML
-<h1 class="fds-headline1">This is headline 1</h1>
+<h1 class="fds-headline-1">This is headline 1</h1>
 ```

--- a/themes/fds-theme/typography/_mixins.scss
+++ b/themes/fds-theme/typography/_mixins.scss
@@ -6,7 +6,7 @@
 ///
 /// @example
 ///   .my-headline {
-///      font: var(--fds-headline1);
+///      font: var(--fds-headline-1);
 ///   }
 @mixin custom-properties() {
   @each $key, $value in variables.$properties {
@@ -27,7 +27,7 @@
 /// Loads the typography's helper classes.
 ///
 /// @example
-///   <p class="fds-body2">Hello</p>
+///   <p class="fds-body-2">Hello</p>
 @mixin helper-classes() {
   @each $key, $value in variables.$properties {
     @if (meta.type-of($value) == 'map') {

--- a/themes/fds-theme/typography/_variables.scss
+++ b/themes/fds-theme/typography/_variables.scss
@@ -11,7 +11,7 @@ $font-family: string.unquote('Roboto') !default;
 $properties: (
   font-family: $font-family,
   headline-font-family: $headline-font-family,
-  headline1: (
+  headline-1: (
     font-family: $headline-font-family,
     font-size: px-to-rem(51px),
     line-height: px-to-rem(71px),
@@ -20,7 +20,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
   ),
-  headline2: (
+  headline-2: (
     font-family: $headline-font-family,
     font-size: px-to-rem(41px),
     line-height: px-to-rem(57px),
@@ -29,7 +29,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
     ),
-  headline3: (
+  headline-3: (
     font-family: $headline-font-family,
     font-size: px-to-rem(28px),
     line-height: px-to-rem(39px),
@@ -38,7 +38,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
   ),
-  headline4: (
+  headline-4: (
     font-family: $headline-font-family,
     font-size: px-to-rem(21px),
     line-height: px-to-rem(29px),
@@ -47,7 +47,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
   ),
-  headline5: (
+  headline-5: (
     font-family: $headline-font-family,
     font-size: px-to-rem(16px),
     line-height: px-to-rem(22px),
@@ -56,7 +56,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
   ),
-  headline6: (
+  headline-6: (
     font-family: $headline-font-family,
     font-size: px-to-rem(13px),
     line-height: px-to-rem(18px),
@@ -65,7 +65,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
   ),
-  subtitle1: (
+  subtitle-1: (
     font-size: px-to-rem(16px),
     line-height: px-to-rem(24px),
     font-weight: 500,
@@ -73,7 +73,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
   ),
-  subtitle2: (
+  subtitle-2: (
     font-size: px-to-rem(14px),
     line-height: px-to-rem(21px),
     font-weight: 500,
@@ -81,7 +81,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
   ),
-  subtitle3: (
+  subtitle-3: (
     font-size: px-to-rem(12px),
     line-height: px-to-rem(18px),
     font-weight: 500,
@@ -89,7 +89,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
   ),
-  body1: (
+  body-1: (
     font-size: px-to-rem(16px),
     line-height: px-to-rem(24px),
     font-weight: 300,
@@ -97,7 +97,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
   ),
-  body2: (
+  body-2: (
     font-size: px-to-rem(14px),
     line-height: px-to-rem(21px),
     font-weight: 300,
@@ -105,7 +105,7 @@ $properties: (
     text-decoration: inherit,
     text-transform: inherit,
   ),
-  body3: (
+  body-3: (
     font-size: px-to-rem(12px),
     line-height: px-to-rem(18px),
     font-weight: 300,


### PR DESCRIPTION
To be consistent with spacing and elevation that are written with dash numbers like so:
fds-spacing-1 or fds-elevation-2
We are changing typo names to include dash as well:
previously fds-headline2 -> now fds-headline-2