### PR TITLE
chore(config): increase cypress diff threshold

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,8 @@
 import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command';
 
-addMatchImageSnapshotCommand();
+addMatchImageSnapshotCommand({
+  failureThreshold: 0.03, // threshold for entire image
+  failureThresholdType: 'percent', // percent of image or number of pixels
+  customDiffConfig: { threshold: 0.11 }, // threshold for each pixel
+  capture: 'viewport' // capture viewport in screenshot
+});


### PR DESCRIPTION
Resolving Cypress false positive happening almost everytime:

```
1) UI Elements
       match list avatar:
     Error: Image was 0.21052631578947367% different from saved snapshot with 16 different pixels.
See diff for details: /home/runner/work/finastra-design-system/finastra-design-system/cypress/snapshots/ui-elements.spec.js/__diff_output__/UI Elements -- match list avatar.diff.png
      at Context.eval (http://localhost:4200/__cypress/tests?p=cypress/support/index.js:81:17)

  2) UI Elements
       match card workspace dense:
     Error: Image was 0.002467308166790032% different from saved snapshot with 1 different pixels.
See diff for details: /home/runner/work/finastra-design-system/finastra-design-system/cypress/snapshots/ui-elements.spec.js/__diff_output__/UI Elements -- match card workspace dense.diff.png
      at Context.eval (http://localhost:4200/__cypress/tests?p=cypress/support/index.js:81:17)
```