### PR TITLE
fix(wc-generator): remove 'fds' from the generated file name

### DIFF
--- a/tools/generators/web-component/index.ts
+++ b/tools/generators/web-component/index.ts
@@ -10,6 +10,11 @@ import {
 } from '@nrwl/devkit';
 
 export default async function (host: Tree, schema: any) {
+
+  // Starts with fds- or fds
+  const regex=/^(fds\-|fds)/i
+  schema.name = schema.name.replace(regex,'');
+
   const normalizedNames = names(schema.name);
 
   generateFiles(host, joinPathFragments(__dirname, './files'), `./libs/web-components/${normalizedNames.fileName}`, {


### PR DESCRIPTION
`npm run wc:generate fds-button` will generate web-components/button instead of web-components/fds-button.

Same for a file name that starts with fds like fdsButton.