### PR TITLE
fix(fds-button): icon vertical align in storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -9,7 +9,6 @@
 <style>
   body {
     justify-content: center;
-    font: var(--fds-body-1);
   }
 
   body #root {


### PR DESCRIPTION
Fix incorrect alignment of icon in storybook render

![image](https://user-images.githubusercontent.com/371041/169978128-53986519-1954-470b-b6a0-db697cc33740.png)
