### PR TITLE
feat(textfield): apply v2 design

### DIFF
--- a/libs/web-components/textfield/demo/index.html
+++ b/libs/web-components/textfield/demo/index.html
@@ -1,32 +1,33 @@
 <script type="module" src="node_modules/@finastra/textfield/dist/src/textfield.js"></script>
+<script type="module" src="node_modules/@finastra/icon-button/dist/src/icon-button.js"></script>
 
 <div>
-  <fds-textfield type="password" showActionButton id="my-textfield" dense>
-    <mwc-icon-button slot="actionButton" icon="visibility_off" onclick="myFunction(this.icon)"></mwc-icon-button>
+  <fds-textfield type="password" showActionButton id="my-textfield-dense" dense>
+    <fds-icon-button slot="actionButton" icon="visibility_off" onclick="myFunction(this)"></fds-icon-button>
   </fds-textfield>
   <fds-textfield label="Label" placeholder="Placeholder" icon="person_outline" helper="fill it like this" dense>
   </fds-textfield>
-  <fds-textfield label="Label" placeholder="Placeholder" icon="lock_outline" dense>
+  <fds-textfield label="Label" placeholder="Placeholder" labelInside dense>
   </fds-textfield>
 
-  <fds-textfield type="password" showActionButton id="my-textfield">
-    <mwc-icon-button slot="actionButton" icon="visibility_off" onclick="myFunction(this.icon)"></mwc-icon-button>
+  <fds-textfield type="password" icon="favorite_outline" label="favorite thing" labelInside showActionButton id="my-textfield">
+    <fds-icon-button slot="actionButton" icon="visibility_off" onclick="myFunction(this)"></fds-icon-button>
   </fds-textfield>
-  <fds-textfield label="Label" placeholder="Placeholder" icon="person_outline" helper="fill it like this" labelInside>
+  <fds-textfield label="Label" placeholder="Placeholder" icon="person_outline" helper="limited char num" validationMessage="this field is required" labelInside maxLength="15" charCounter required>
   </fds-textfield>
-  <fds-textfield label="Label" placeholder="Placeholder" icon="lock_outline">
+  <fds-textfield label="Label" showActionButton placeholder="Placeholder" icon="lock_outline" disabled>
+    <fds-icon-button slot="actionButton" icon="visibility_off" onclick="myFunction(this)"></fds-icon-button>
   </fds-textfield>
 </div>
 
 <script>
   function myFunction(e) {
-    const textfield = document.querySelector('#my-textfield');
-    const iconButton = document.querySelector('#my-textfield mwc-icon-button');
-    if (iconButton.getAttribute('icon') == 'visibility_off') {
-      iconButton.setAttribute('icon', 'visibility_on');
+    const textfield = e.parentNode;
+    if (e.getAttribute('icon') == 'visibility_off') {
+      e.setAttribute('icon', 'visibility_on');
       textfield.setAttribute('type', 'text');
     } else {
-      iconButton.setAttribute('icon', 'visibility_off');
+      e.setAttribute('icon', 'visibility_off');
       textfield.setAttribute('type', 'password');
     }
   }

--- a/libs/web-components/textfield/demo/index.html
+++ b/libs/web-components/textfield/demo/index.html
@@ -1,8 +1,23 @@
 <script type="module" src="node_modules/@finastra/textfield/dist/src/textfield.js"></script>
 
-<fds-textfield type="password" showActionButton id="my-textfield">
-  <mwc-icon-button slot="actionButton" icon="visibility_off" onclick="myFunction(this.icon)"></mwc-icon-button>
-</fds-textfield>
+<div>
+  <fds-textfield type="password" showActionButton id="my-textfield" dense>
+    <mwc-icon-button slot="actionButton" icon="visibility_off" onclick="myFunction(this.icon)"></mwc-icon-button>
+  </fds-textfield>
+  <fds-textfield label="Label" placeholder="Placeholder" icon="person_outline" helper="fill it like this" dense>
+  </fds-textfield>
+  <fds-textfield label="Label" placeholder="Placeholder" icon="lock_outline" dense>
+  </fds-textfield>
+
+  <fds-textfield type="password" showActionButton id="my-textfield">
+    <mwc-icon-button slot="actionButton" icon="visibility_off" onclick="myFunction(this.icon)"></mwc-icon-button>
+  </fds-textfield>
+  <fds-textfield label="Label" placeholder="Placeholder" icon="person_outline" helper="fill it like this" labelInside>
+  </fds-textfield>
+  <fds-textfield label="Label" placeholder="Placeholder" icon="lock_outline">
+  </fds-textfield>
+</div>
+
 <script>
   function myFunction(e) {
     const textfield = document.querySelector('#my-textfield');

--- a/libs/web-components/textfield/src/styles.scss
+++ b/libs/web-components/textfield/src/styles.scss
@@ -7,24 +7,27 @@ $textfield-icon-trailing-color: var(--fds-primary, #694ed6);
 :host {
   display: block;
   @include fds.mdc(theme-primary, primary);
-  @include fds.mdc(text-field-fill-color, surface-selected);
-  @include fds.mdc(text-field-idle-line-color, primary);
+  @include fds.mdc(text-field-outlined-idle-border-color, outline);
+  @include fds.mdc(text-field-outlined-hover-border-color, on-surface);
+  @include fds.mdc(text-field-outlined-disabled-border-color, outline);
+  @include fds.mdc(text-field-ink-color, on-surface);
   @include fds.mdc(text-field-label-ink-color, on-surface-medium);
-  @include fds.mdc(text-field-idle-line-color, primary);
-  @include fds.mdc(text-field-hover-line-color, primary);
-  @include fds.mdc(text-field-ink-color, on-background);
-  @include fds.mdc(text-field-outlined-idle-border-color, primary);
-  @include fds.mdc(text-field-outlined-hover-border-color, primary);
-  @include fds.mdc(ripple-color, surface-selected);
-  @include fds.mdc(text-field-disabled-fill-color, surface-disabled);
-  @include fds.mdc(text-field-disabled-ink-color, on-surface-disabled);
-  @include fds.mdc(text-field-error-color, error);
-  @include fds.mdc(text-field-disabled-line-color, on-surface-disabled);
 }
 
 slot[name="actionButton"]::slotted(*) {
   @include fds.text-color(on-background);
   align-self: center;
+}
+
+.mdc-text-field--outlined {
+  height: 48px;
+}
+
+.mdc-text-field--outlined.mdc-text-field--with-leading-icon {
+  @include fds.bg-color(surface);
+}
+.mdc-text-field--outlined.mdc-text-field--with-leading-icon.mdc-text-field--disabled {
+  @include fds.bg-color(surface-disabled);
 }
 
 .mdc-text-field:not(.mdc-text-field--disabled) .mdc-text-field__icon--leading {

--- a/libs/web-components/textfield/src/styles.scss
+++ b/libs/web-components/textfield/src/styles.scss
@@ -18,8 +18,10 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
   @include fds.mdc(text-field-disabled-ink-color, on-surface-disabled);
 
   .fds-text-field__label {
+    display: block;
     @include fds.text-color(on-surface-medium);
     @include fds.typography(body-2);
+    @include fds.margin(2, bottom);
   }
 
   .mdc-text-field--outlined {

--- a/libs/web-components/textfield/src/styles.scss
+++ b/libs/web-components/textfield/src/styles.scss
@@ -8,12 +8,21 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
 :host {
   display: block;
   @include fds.mdc(theme-primary, primary);
+  @include fds.mdc(theme-error, error);
   @include fds.mdc(text-field-outlined-idle-border-color, outline);
   @include fds.mdc(text-field-outlined-hover-border-color, on-surface);
   @include fds.mdc(text-field-outlined-disabled-border-color, outline);
   @include fds.mdc(text-field-ink-color, on-surface);
   @include fds.mdc(text-field-label-ink-color, on-surface-medium);
   @include fds.mdc(text-field-disabled-ink-color, on-surface-disabled);
+
+  .fds-text-field__label {
+    @include fds.text-color(on-surface-medium);
+    @include fds.typography(body-2);
+    position: relative;
+    top: -26px;
+    left: -12px;
+  }
 
   .mdc-text-field--outlined {
     @include fds.bg-color(surface);
@@ -26,10 +35,6 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
     &::placeholder {
       @include fds.typography(body-2);
     }
-  }
-  
-  .mdc-floating-label {
-    @include fds.typography(body-2);
   }
 
   .mdc-text-field--disabled {
@@ -52,7 +57,7 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
     @include fds.typography(subtitle-3);
   }
 
-  .mdc-floating-label {
+  .fds-text-field__label {
     @include fds.typography(body-3);
   }
 }

--- a/libs/web-components/textfield/src/styles.scss
+++ b/libs/web-components/textfield/src/styles.scss
@@ -3,42 +3,87 @@
 @use "@finastra/fds-theme" as fds;
 
 $textfield-icon-color: var(--fds-primary, #694ed6);
-$textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, $alpha: 0.54),);
+$textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, $alpha: 0.54));
+
+
 
 :host {
-  padding-top: 30px;
+  padding-top: 24px;
   display: block;
   @include fds.mdc(theme-primary, primary);
   @include fds.mdc(theme-error, error);
-  @include fds.mdc(text-field-outlined-idle-border-color, outline);
-  @include fds.mdc(text-field-outlined-hover-border-color, on-surface);
-  @include fds.mdc(text-field-outlined-disabled-border-color, outline);
   @include fds.mdc(text-field-ink-color, on-surface);
   @include fds.mdc(text-field-label-ink-color, on-surface-medium);
   @include fds.mdc(text-field-disabled-ink-color, on-surface-disabled);
 
-  .mdc-notched-outline--notched .mdc-notched-outline__notch {
-    border-top: 1px solid red !important;
+  .fds-text-field__outline {
+    @include fds.property(border-color, outline);
+    box-sizing: border-box;
+    position: absolute;
+    text-align: left;
+    right: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 4px;
+    pointer-events: none;
+  }
+
+  .fds-text-field__outline .mdc-floating-label {
+    position: relative;
+    display: inline-block;
+  }
+
+  .mdc-text-field:hover:not(.mdc-text-field--focused):not(.mdc-text-field--disabled):not(.mdc-text-field--invalid) .fds-text-field__outline {
+    @include fds.property(border-color, on-surface-medium);
+  }
+
+  .fds-text-field__outline:disabled {
+    @include fds.property(border-color, outline);
+  }
+
+  .mdc-text-field--focused .fds-text-field__outline {
+    @include fds.property(border-color, primary);
+    border-width: 2px;
+  }
+
+  .mdc-text-field--invalid .fds-text-field__outline {
+    @include fds.property(border-color, error);
   }
 
   .fds-text-field__label,
   .mdc-floating-label {
-    display: block;
     @include fds.text-color(on-surface-medium);
     @include fds.typography(body-2);
-    @include fds.margin(2, bottom);
+    @include fds.margin(1, bottom);
+    display: block;
+  }
+
+  .mdc-floating-label {
+    margin-left: 10px;
+  }
+
+  &:disabled .fds-text-field__label {
+    @include fds.text-color(on-surface-disabled);
   }
 
   .mdc-floating-label--float-above {
     max-width: 100% !important;
     text-overflow: unset !important;
-    transform: translateY(-18px)
-          scale(0.94) !important;
+    transform: translateY(-18px) !important;
+    font-size: 0.75em;
   }
 
   .mdc-text-field--outlined {
     @include fds.bg-color(surface);
     height: 48px;
+  }
+
+  .mdc-text-field.mdc-text-field--focused.mdc-text-field--invalid {
+    @include fds.bg-color(surface-error);
   }
 
   .mdc-text-field__input {
@@ -68,6 +113,11 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
   .mdc-text-field.mdc-text-field--focused {
     @include fds.bg-color(surface-selected);
   }
+
+  .mdc-text-field-character-counter,
+  .mdc-text-field-helper-text {
+    @include fds.typography(body-3);
+  }
 }
 
 :host([dense]) {
@@ -84,6 +134,10 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
   .fds-text-field__label {
     @include fds.typography(body-3);
   }
+}
+
+:host([disabled]) .fds-text-field__label {
+  @include fds.text-color(on-surface-disabled);
 }
 
 slot[name="actionButton"]::slotted(*) {

--- a/libs/web-components/textfield/src/styles.scss
+++ b/libs/web-components/textfield/src/styles.scss
@@ -17,11 +17,23 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
   @include fds.mdc(text-field-label-ink-color, on-surface-medium);
   @include fds.mdc(text-field-disabled-ink-color, on-surface-disabled);
 
-  .fds-text-field__label {
+  .mdc-notched-outline--notched .mdc-notched-outline__notch {
+    border-top: 1px solid red !important;
+  }
+
+  .fds-text-field__label,
+  .mdc-floating-label {
     display: block;
     @include fds.text-color(on-surface-medium);
     @include fds.typography(body-2);
     @include fds.margin(2, bottom);
+  }
+
+  .mdc-floating-label--float-above {
+    max-width: 100% !important;
+    text-overflow: unset !important;
+    transform: translateY(-18px)
+          scale(0.94) !important;
   }
 
   .mdc-text-field--outlined {
@@ -37,6 +49,12 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
     }
   }
 
+  .mdc-text-field.fds-text-field--label-inside {
+    .mdc-text-field__input {
+      @include fds.margin(2, top);
+    }
+  }
+
   .mdc-text-field:not(.fds-text-field--label-inside) {
     .mdc-text-field__input::placeholder {
       opacity: 1 !important;
@@ -47,8 +65,8 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
     @include fds.bg-color(surface-disabled);
   }
 
-  .mdc-text-field.mdc-text-field--focused .mdc-notched-outline {
-    --mdc-notched-outline-stroke-width: 1px !important;
+  .mdc-text-field.mdc-text-field--focused {
+    @include fds.bg-color(surface-selected);
   }
 }
 

--- a/libs/web-components/textfield/src/styles.scss
+++ b/libs/web-components/textfield/src/styles.scss
@@ -1,8 +1,9 @@
+@use "sass:color";
 @use "@material/mwc-textfield/mwc-textfield";
 @use "@finastra/fds-theme" as fds;
 
 $textfield-icon-color: var(--fds-primary, #694ed6);
-$textfield-icon-trailing-color: var(--fds-primary, #694ed6);
+$textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, $alpha: 0.54),);
 
 :host {
   display: block;
@@ -12,22 +13,53 @@ $textfield-icon-trailing-color: var(--fds-primary, #694ed6);
   @include fds.mdc(text-field-outlined-disabled-border-color, outline);
   @include fds.mdc(text-field-ink-color, on-surface);
   @include fds.mdc(text-field-label-ink-color, on-surface-medium);
+  @include fds.mdc(text-field-disabled-ink-color, on-surface-disabled);
+
+  .mdc-text-field--outlined {
+    @include fds.bg-color(surface);
+    height: 48px;
+  }
+
+  .mdc-text-field__input {
+    @include fds.typography(subtitle-2);
+    
+    &::placeholder {
+      @include fds.typography(body-2);
+    }
+  }
+  
+  .mdc-floating-label {
+    @include fds.typography(body-2);
+  }
+
+  .mdc-text-field--disabled {
+    @include fds.bg-color(surface-disabled);
+  }
+
+  .mdc-text-field.mdc-text-field--focused .mdc-notched-outline {
+    --mdc-notched-outline-stroke-width: 1px !important;
+  }
+}
+
+:host([dense]) {
+  --mdc-icon-size: 18px;
+
+  .mdc-text-field--outlined {
+    height: 40px;
+  }
+  
+  .mdc-text-field__input {
+    @include fds.typography(subtitle-3);
+  }
+
+  .mdc-floating-label {
+    @include fds.typography(body-3);
+  }
 }
 
 slot[name="actionButton"]::slotted(*) {
   @include fds.text-color(on-background);
   align-self: center;
-}
-
-.mdc-text-field--outlined {
-  height: 48px;
-}
-
-.mdc-text-field--outlined.mdc-text-field--with-leading-icon {
-  @include fds.bg-color(surface);
-}
-.mdc-text-field--outlined.mdc-text-field--with-leading-icon.mdc-text-field--disabled {
-  @include fds.bg-color(surface-disabled);
 }
 
 .mdc-text-field:not(.mdc-text-field--disabled) .mdc-text-field__icon--leading {
@@ -38,8 +70,6 @@ slot[name="actionButton"]::slotted(*) {
   color: var(--fds-icon-trailing-color, $textfield-icon-trailing-color);
 }
 
-
-.mdc-text-field--disabled .mdc-text-field__icon--leading {
+.mdc-text-field--disabled .mdc-text-field__icon {
   color: var(--fds-on-surface-disabled);
 }
-

--- a/libs/web-components/textfield/src/styles.scss
+++ b/libs/web-components/textfield/src/styles.scss
@@ -6,6 +6,7 @@ $textfield-icon-color: var(--fds-primary, #694ed6);
 $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, $alpha: 0.54),);
 
 :host {
+  padding-top: 30px;
   display: block;
   @include fds.mdc(theme-primary, primary);
   @include fds.mdc(theme-error, error);
@@ -19,9 +20,6 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
   .fds-text-field__label {
     @include fds.text-color(on-surface-medium);
     @include fds.typography(body-2);
-    position: relative;
-    top: -26px;
-    left: -12px;
   }
 
   .mdc-text-field--outlined {
@@ -34,6 +32,12 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
     
     &::placeholder {
       @include fds.typography(body-2);
+    }
+  }
+
+  .mdc-text-field:not(.fds-text-field--label-inside) {
+    .mdc-text-field__input::placeholder {
+      opacity: 1 !important;
     }
   }
 
@@ -63,7 +67,8 @@ $textfield-icon-trailing-color: var(--fds-on-surface-medium, color.change(#000, 
 }
 
 slot[name="actionButton"]::slotted(*) {
-  @include fds.text-color(on-background);
+  @include fds.text-color(on-surface-medium);
+  margin-right: -14px;
   align-self: center;
 }
 

--- a/libs/web-components/textfield/src/textfield.ts
+++ b/libs/web-components/textfield/src/textfield.ts
@@ -17,8 +17,8 @@ import { styles } from './styles.css';
  * @attr [type=''] - A string specifying the type of control to render.
  * @attr [validationMessage=''] - Message to show in the error color when the textfield is invalid. (Helper text will not be visible)
  * @attr [disabled=false] - Whether or not the input should be disabled.
- * @attr [labelInside=false] - Is the label included in the text field.
  * @attr [helper=''] - Helper text to display below the input.
+ * @attr [labelInside=false] - Is the label included in the text field.
  * @attr [pattern=''] - A JavaScript regular expression. The textfield value must match this pattern.
  * @attr [showActionButton=false] - Enable the use of a the actionButton slot.
  * @slot actionButton - Slot to replace iconTrailing with an action button.

--- a/libs/web-components/textfield/src/textfield.ts
+++ b/libs/web-components/textfield/src/textfield.ts
@@ -2,6 +2,7 @@ import { TextFieldBase } from '@material/mwc-textfield/mwc-textfield-base';
 import { customElement, property } from 'lit/decorators.js';
 
 import { html, TemplateResult } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
 import { styles } from './styles.css';
 
 /**
@@ -27,10 +28,44 @@ export class Textfield extends TextFieldBase {
   static styles = [styles];
   @property({ type: Boolean }) showActionButton = false;
   @property({ type: Boolean }) dense = false;
+  @property({ type: Boolean }) labelInside = false;
   constructor() {
     super();
     this.outlined = true;
     this.helperPersistent = true;
+  }
+
+  override render(): TemplateResult {
+    const shouldRenderCharCounter = this.charCounter && this.maxLength !== -1;
+    const shouldRenderHelperText =
+        !!this.helper || !!this.validationMessage || shouldRenderCharCounter;
+
+    /** @classMap */
+    const classes = {
+      'mdc-text-field--disabled': this.disabled,
+      'mdc-text-field--no-label': !this.label,
+      'mdc-text-field--filled': !this.outlined,
+      'mdc-text-field--outlined': this.outlined,
+      'mdc-text-field--with-leading-icon': this.icon,
+      'mdc-text-field--with-trailing-icon': this.iconTrailing,
+      'mdc-text-field--end-aligned': this.endAligned,
+      'fds-text-field--label-inside': this.labelInside
+    };
+
+    return html`
+      ${!this.labelInside ? this.renderLabelOutside() : ''}
+      <label class="mdc-text-field ${classMap(classes)}">
+        ${this.renderRipple()}
+        ${this.renderOutline()}
+        ${this.renderLeadingIcon()}
+        ${this.renderPrefix()}
+        ${this.renderInput(shouldRenderHelperText)}
+        ${this.renderSuffix()}
+        ${this.renderTrailingIcon()}
+        ${this.renderLineRipple()}
+      </label>
+      ${this.renderHelperText(shouldRenderHelperText, shouldRenderCharCounter)}
+    `;
   }
 
   protected renderTrailingIcon(): TemplateResult | string {
@@ -40,15 +75,23 @@ export class Textfield extends TextFieldBase {
       : html`<i class="material-icons mdc-text-field__icon  mdc-text-field__icon--trailing">${this.iconTrailing}</i> `;
   }
 
-  protected override renderLabel(): TemplateResult | string {
-    return !this.label ?
-        '' :
-        html`
+  protected renderLabelOutside(): TemplateResult | string {
+    return html`
       <span class="fds-text-field__label">
         ${this.label}
         ${this.renderRequired()}
       </span>
     `;
+  }
+
+  protected override renderOutline(): TemplateResult|string {
+    return !this.outlined ? '' : html`
+      <mwc-notched-outline
+          .width=${this.outlineWidth}
+          .open=${this.outlineOpen}
+          class="mdc-notched-outline">
+        ${this.labelInside ? this.renderLabel() : ''}
+      </mwc-notched-outline>`;
   }
 
   protected renderRequired(): TemplateResult | string {

--- a/libs/web-components/textfield/src/textfield.ts
+++ b/libs/web-components/textfield/src/textfield.ts
@@ -9,6 +9,7 @@ import { styles } from './styles.css';
  * @cssprop {color} [--fds-icon-color=#694ED6] - Icon color.
  * @cssprop {color} [--fds-icon-trailing-color=#694ED6] - Icon trailing color.
  * @attr [label='textfield'] - Sets floating label value.
+ * @attr [placeholder='textfield'] - Sets placeholder value displayed when input is empty.
  * @attr [required=false] - Displays error state if value is empty and input is blurred.
  * @attr [icon=''] - Leading icon to display in input. See `mwc-icon`.
  * @attr [iconTrailing=''] - Leading icon to display in input. See `mwc-icon`.
@@ -25,6 +26,7 @@ import { styles } from './styles.css';
 export class Textfield extends TextFieldBase {
   static styles = [styles];
   @property({ type: Boolean }) showActionButton = false;
+  @property({ type: Boolean }) dense = false;
   constructor() {
     super();
     this.outlined = true;

--- a/libs/web-components/textfield/src/textfield.ts
+++ b/libs/web-components/textfield/src/textfield.ts
@@ -1,8 +1,8 @@
-import { customElement, property } from 'lit/decorators.js';
 import { TextFieldBase } from '@material/mwc-textfield/mwc-textfield-base';
+import { customElement, property } from 'lit/decorators.js';
 
-import { styles } from './styles.css';
 import { html, TemplateResult } from 'lit';
+import { styles } from './styles.css';
 
 /**
  * @cssprop {color} [--fds-primary=#694ED6] - Textfield color
@@ -27,6 +27,7 @@ export class Textfield extends TextFieldBase {
   @property({ type: Boolean }) showActionButton = false;
   constructor() {
     super();
+    this.outlined = true;
   }
 
   protected renderTrailingIcon(): TemplateResult | string {

--- a/libs/web-components/textfield/src/textfield.ts
+++ b/libs/web-components/textfield/src/textfield.ts
@@ -96,6 +96,18 @@ export class Textfield extends TextFieldBase {
     '' :
     '*';
   }
+
+  updated(changedProperties) {
+    super.updated(changedProperties);
+    for(const child of Array.from(this.children)) {
+      if(child.slot === "actionButton" && this.disabled) {
+        child.setAttribute("disabled", "true");
+      }
+      else if(child.slot === "actionButton") {
+        child.removeAttribute("disabled");
+      }
+    }
+  }
 }
 
 declare global {

--- a/libs/web-components/textfield/src/textfield.ts
+++ b/libs/web-components/textfield/src/textfield.ts
@@ -77,7 +77,7 @@ export class Textfield extends TextFieldBase {
 
   protected renderLabelOutside(): TemplateResult | string {
     return html`
-      <span class="fds-text-field__label">
+      <span id="label" class="fds-text-field__label">
         ${this.label}
         ${this.renderRequired()}
       </span>

--- a/libs/web-components/textfield/src/textfield.ts
+++ b/libs/web-components/textfield/src/textfield.ts
@@ -17,6 +17,7 @@ import { styles } from './styles.css';
  * @attr [type=''] - A string specifying the type of control to render.
  * @attr [validationMessage=''] - Message to show in the error color when the textfield is invalid. (Helper text will not be visible)
  * @attr [disabled=false] - Whether or not the input should be disabled.
+ * @attr [labelInside=false] - Is the label included in the text field.
  * @attr [helper=''] - Helper text to display below the input.
  * @attr [pattern=''] - A JavaScript regular expression. The textfield value must match this pattern.
  * @attr [showActionButton=false] - Enable the use of a the actionButton slot.

--- a/libs/web-components/textfield/src/textfield.ts
+++ b/libs/web-components/textfield/src/textfield.ts
@@ -17,6 +17,7 @@ import { styles } from './styles.css';
  * @attr [type=''] - A string specifying the type of control to render.
  * @attr [validationMessage=''] - Message to show in the error color when the textfield is invalid. (Helper text will not be visible)
  * @attr [disabled=false] - Whether or not the input should be disabled.
+ * @attr [dense=false] - Smaller text field size.
  * @attr [helper=''] - Helper text to display below the input.
  * @attr [labelInside=false] - Is the label included in the text field.
  * @attr [pattern=''] - A JavaScript regular expression. The textfield value must match this pattern.

--- a/libs/web-components/textfield/src/textfield.ts
+++ b/libs/web-components/textfield/src/textfield.ts
@@ -86,12 +86,9 @@ export class Textfield extends TextFieldBase {
 
   protected override renderOutline(): TemplateResult|string {
     return !this.outlined ? '' : html`
-      <mwc-notched-outline
-          .width=${this.outlineWidth}
-          .open=${this.outlineOpen}
-          class="mdc-notched-outline">
+      <div class="fds-text-field__outline">
         ${this.labelInside ? this.renderLabel() : ''}
-      </mwc-notched-outline>`;
+      </div>`;
   }
 
   protected renderRequired(): TemplateResult | string {

--- a/libs/web-components/textfield/src/textfield.ts
+++ b/libs/web-components/textfield/src/textfield.ts
@@ -16,7 +16,7 @@ import { styles } from './styles.css';
  * @attr [type=''] - A string specifying the type of control to render.
  * @attr [validationMessage=''] - Message to show in the error color when the textfield is invalid. (Helper text will not be visible)
  * @attr [disabled=false] - Whether or not the input should be disabled.
- * @attr [helper=''] - Helper text to display below the input. Display default only when focused.
+ * @attr [helper=''] - Helper text to display below the input.
  * @attr [pattern=''] - A JavaScript regular expression. The textfield value must match this pattern.
  * @attr [showActionButton=false] - Enable the use of a the actionButton slot.
  * @slot actionButton - Slot to replace iconTrailing with an action button.
@@ -30,6 +30,7 @@ export class Textfield extends TextFieldBase {
   constructor() {
     super();
     this.outlined = true;
+    this.helperPersistent = true;
   }
 
   protected renderTrailingIcon(): TemplateResult | string {
@@ -37,6 +38,23 @@ export class Textfield extends TextFieldBase {
       ? html`
       <slot name="actionButton"></slot>`
       : html`<i class="material-icons mdc-text-field__icon  mdc-text-field__icon--trailing">${this.iconTrailing}</i> `;
+  }
+
+  protected override renderLabel(): TemplateResult | string {
+    return !this.label ?
+        '' :
+        html`
+      <span class="fds-text-field__label">
+        ${this.label}
+        ${this.renderRequired()}
+      </span>
+    `;
+  }
+
+  protected renderRequired(): TemplateResult | string {
+    return !this.required ?
+    '' :
+    '*';
   }
 }
 

--- a/libs/web-components/textfield/stories/textfield.stories.ts
+++ b/libs/web-components/textfield/stories/textfield.stories.ts
@@ -37,21 +37,21 @@ export const Default: Story<Textfield> = Template.bind({});
 Default.args = {
   label: 'Label',
   placeholder: 'Placeholder',
-  icon: 'person',
-  helper: "helper text"
+  icon: 'person_outline',
+  helper: "Helper text"
 };
 
 export const Dense: Story<Textfield> = Default.bind({});
 Dense.args = {
   dense: true,
-  icon: 'person'
+  icon: 'person_outline'
 };
 
 export const Password: Story<Textfield> = ActionButtonTemplate.bind({});
 Password.args = {
   label: 'Enter your password',
   type: 'password',
-  helper: "helper text",
+  helper: "Helper text",
   showActionButton: true,
   icon: 'visibility_off'
 };

--- a/libs/web-components/textfield/stories/textfield.stories.ts
+++ b/libs/web-components/textfield/stories/textfield.stories.ts
@@ -17,8 +17,8 @@ export default {
   },
 } as Meta;
 
-const Template: Story<Textfield> = ({ label, icon, disabled, required, iconTrailing,helper}) => {
-  return html`<fds-textfield label=${label} icon=${icon} ?disabled=${disabled} ?required=${required} iconTrailing=${iconTrailing} helper=${helper}></fds-textfield>`;
+const Template: Story<Textfield> = ({ label, placeholder, icon, disabled, dense, required, iconTrailing,helper}) => {
+  return html`<fds-textfield label=${label} placeholder=${placeholder} icon=${icon} ?disabled=${disabled} ?dense=${dense} ?required=${required} iconTrailing=${iconTrailing} helper=${helper}></fds-textfield>`;
 };
 
 const ValidationTemplate: Story<Textfield> = ({ label, icon, helper, type, validationMessage,pattern}) => {
@@ -35,9 +35,16 @@ const ActionButtonTemplate: Story<Textfield> = ({ label, icon, type, helper, sho
 
 export const Default: Story<Textfield> = Template.bind({});
 Default.args = {
-  label: 'Default',
-  icon: 'event',
+  label: 'Label',
+  placeholder: 'Placeholder',
+  icon: 'person',
   helper: "helper text"
+};
+
+export const Dense: Story<Textfield> = Default.bind({});
+Dense.args = {
+  dense: true,
+  icon: 'person'
 };
 
 export const Password: Story<Textfield> = ActionButtonTemplate.bind({});

--- a/libs/web-components/textfield/stories/textfield.stories.ts
+++ b/libs/web-components/textfield/stories/textfield.stories.ts
@@ -17,8 +17,8 @@ export default {
   },
 } as Meta;
 
-const Template: Story<Textfield> = ({ label, placeholder, icon, disabled, dense, required, iconTrailing,helper}) => {
-  return html`<fds-textfield label=${label} placeholder=${placeholder} icon=${icon} ?disabled=${disabled} ?dense=${dense} ?required=${required} iconTrailing=${iconTrailing} helper=${helper}></fds-textfield>`;
+const Template: Story<Textfield> = ({ label, placeholder, icon, disabled, dense, required, iconTrailing, helper, labelInside}) => {
+  return html`<fds-textfield label=${label} placeholder=${placeholder} icon=${icon} ?disabled=${disabled} ?dense=${dense} ?required=${required} iconTrailing=${iconTrailing} helper=${helper} ?labelInside=${labelInside}></fds-textfield>`;
 };
 
 const ValidationTemplate: Story<Textfield> = ({ label, icon, helper, type, validationMessage,pattern}) => {
@@ -27,7 +27,7 @@ const ValidationTemplate: Story<Textfield> = ({ label, icon, helper, type, valid
 
 const ActionButtonTemplate: Story<Textfield> = ({ label, icon, type, helper, showActionButton}) => {
   return html`
-    <fds-textfield showActionButton=${showActionButton} label=${label} type=${type} helper=${helper}>
+    <fds-textfield icon="lock_outline" showActionButton=${showActionButton} label=${label} type=${type} helper=${helper}>
   <mwc-icon-button slot="actionButton" icon=${icon}></mwc-icon-button>
 </fds-textfield>
    `;
@@ -61,7 +61,7 @@ IconTrailing.args = {
   label: 'Icon trailing',
   helper: "helper text",
   icon: 'event',
-  iconTrailing: "favorite"
+  iconTrailing: "favorite_outline"
 };
 
 export const Required: Story<Textfield> = Template.bind({});
@@ -78,7 +78,7 @@ ErrorMessage.args = {
   type: 'email',
   validationMessage: 'Not a valid email',
   label: 'Enter your email',
-  icon: 'event'
+  icon: 'mail_outline'
 };
 
 export const Regex: Story<Textfield> = ValidationTemplate.bind({});
@@ -95,3 +95,12 @@ Disabled.args = {
   icon: 'event',
   disabled: true
 };
+
+export const LabelInside: Story<Textfield> = Template.bind({});
+LabelInside.args = {
+  label: 'Label',
+  labelInside: true,
+  placeholder: 'Placeholder',
+  icon: 'person_outline',
+  helper: "Helper text"
+}


### PR DESCRIPTION
Implement new textfield design:

- [x] Fix placeholder not displayed before focus
- [x] Make sure spacing between multiple textfield stacked is correct
- [x] Manage label inside
- [x] Fix action button disabled
- [ ] Fix inside label moving 1px when input selected
- [x] Update Storybook doc

![image](https://user-images.githubusercontent.com/371041/177945541-dc453682-346e-47e0-bb62-e5ff7aa4d863.png)
