### PR TITLE
feat(textfield): applying v2 outline style

### DIFF
--- a/apps/angular-test-app/src/app/components/ui-elements-demo/ui-elements-demo.component.html
+++ b/apps/angular-test-app/src/app/components/ui-elements-demo/ui-elements-demo.component.html
@@ -668,7 +668,6 @@
       </mat-form-field>
     </div>
   </div>
-
 </div>
 
 <div>

--- a/apps/angular-test-app/src/app/components/ui-elements-demo/ui-elements-demo.component.html
+++ b/apps/angular-test-app/src/app/components/ui-elements-demo/ui-elements-demo.component.html
@@ -494,20 +494,20 @@
   <h3 class="uxg-display-3">Inputs</h3>
   <h5 class="uxg-h5">Fill Input</h5>
   <div class="example-row">
-    <mat-form-field floatLabel="never" appearance="fill">
+    <mat-form-field floatLabel="never" appearance="outline">
       <mat-icon color="primary" matPrefix>favorite</mat-icon>
       <input matInput placeholder="Placeholder" />
       <mat-icon color="primary" matSuffix>favorite</mat-icon>
     </mat-form-field>
   </div>
   <div class="example-row">
-    <mat-form-field floatLabel="never" appearance="fill">
+    <mat-form-field floatLabel="never" appearance="outline">
       <input matInput placeholder="Placeholder" />
       <mat-hint>Helper text</mat-hint>
     </mat-form-field>
   </div>
   <div class="example-row">
-    <mat-form-field floatLabel="never" class="example-full-width" appearance="fill">
+    <mat-form-field floatLabel="never" class="example-full-width" appearance="outline">
       <mat-icon color="primary" matPrefix>search</mat-icon>
       <mat-label>Search...</mat-label>
       <input type="search" matInput />
@@ -516,7 +516,7 @@
 
   <h5 class="uxg-h5">Input With Icon Button</h5>
   <div class="example-container" dense>
-    <mat-form-field appearance="fill">
+    <mat-form-field appearance="outline">
       <mat-label>Enter your password</mat-label>
       <input matInput [type]="hide ? 'password' : 'text'" />
       <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
@@ -525,7 +525,7 @@
     </mat-form-field>
   </div>
   <div>
-    <mat-form-field appearance="fill">
+    <mat-form-field appearance="outline">
       <mat-label>Amount</mat-label>
       <input matInput type="number" value="0" class="example-right-align" />
       <span matPrefix>$&nbsp;</span>
@@ -535,7 +535,7 @@
 
   <h5 class="uxg-h5">Error Message</h5>
   <div class="example-container">
-    <mat-form-field #ff1 appearance="fill">
+    <mat-form-field #ff1 appearance="outline">
       <mat-icon matPrefix>lock_outlined</mat-icon>
       <mat-label>Enter your email</mat-label>
       <input matInput placeholder="pat@example.com" [formControl]="email" required />
@@ -547,18 +547,18 @@
   <h5 class="uxg-h5">Dense Inputs</h5>
   <div class="example-container">
     <div class="example-row">
-      <mat-form-field dense appearance="fill">
+      <mat-form-field dense appearance="outline">
         <input matInput value="this is value" />
       </mat-form-field>
     </div>
     <div class="example-row">
-      <mat-form-field dense appearance="fill">
+      <mat-form-field dense appearance="outline">
         <mat-icon color="primary" matPrefix dense>search</mat-icon>
         <input matInput value="this is value" />
       </mat-form-field>
     </div>
     <div class="example-row">
-      <mat-form-field dense appearance="fill">
+      <mat-form-field dense appearance="outline">
         <mat-label>Label</mat-label>
         <input matInput />
         <mat-hint>Helper text</mat-hint>
@@ -566,7 +566,7 @@
     </div>
     <div>
       <form class="example-form">
-        <mat-form-field dense floatLabel="never" class="example-full-width" appearance="fill">
+        <mat-form-field dense floatLabel="never" class="example-full-width" appearance="outline">
           <mat-icon color="primary" matPrefix dense>search</mat-icon>
           <mat-label>Search...</mat-label>
           <input type="search" matInput />
@@ -575,7 +575,7 @@
     </div>
 
     <div>
-      <mat-form-field dense appearance="fill">
+      <mat-form-field dense appearance="outline">
         <mat-label>Enter your password</mat-label>
         <input matInput [type]="hide ? 'password' : 'text'" />
         <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
@@ -584,7 +584,7 @@
       </mat-form-field>
     </div>
     <div>
-      <mat-form-field dense appearance="fill">
+      <mat-form-field dense appearance="outline">
         <mat-label>Amount</mat-label>
         <input matInput type="number" value="0" class="example-right-align" />
         <span matPrefix>$&nbsp;</span>
@@ -594,7 +594,7 @@
   </div>
 
   <div class="example-container">
-    <mat-form-field #ff2 dense appearance="fill">
+    <mat-form-field #ff2 dense appearance="outline">
       <mat-icon matPrefix dense>lock_outlined</mat-icon>
       <mat-label>Enter your email</mat-label>
       <input matInput placeholder="pat@example.com" [formControl]="email" required />
@@ -607,7 +607,7 @@
   <h5 class="uxg-h5">Select</h5>
   <div class="example-row">
     <div>
-      <mat-form-field appearance="fill">
+      <mat-form-field appearance="outline">
         <mat-label>Font size</mat-label>
         <mat-select value="16px">
           <mat-option value="10px">10px</mat-option>
@@ -621,7 +621,7 @@
     </div>
     <div>
       <p class="uxg-body-3">No label</p>
-      <mat-form-field appearance="fill">
+      <mat-form-field appearance="outline">
         <mat-select value="16px">
           <mat-option value="10px">10px</mat-option>
           <mat-option value="12px">12px</mat-option>
@@ -637,7 +637,7 @@
   <h5 class="uxg-h5">Dense select</h5>
   <div class="example-row">
     <div>
-      <mat-form-field appearance="fill" dense>
+      <mat-form-field appearance="outline" dense>
         <mat-label>Font size</mat-label>
         <mat-select value="16px">
           <mat-option value="10px">10px</mat-option>
@@ -651,7 +651,7 @@
     </div>
     <div>
       <p class="uxg-body-3">Multi-select, no default value</p>
-      <mat-form-field appearance="fill" dense>
+      <mat-form-field appearance="outline" dense>
         <mat-label> Colors </mat-label>
         <mat-select multiple>
           <mat-option value="Violet">Violet</mat-option>

--- a/apps/angular-test-app/src/app/components/ui-elements-demo/ui-elements-demo.component.html
+++ b/apps/angular-test-app/src/app/components/ui-elements-demo/ui-elements-demo.component.html
@@ -580,25 +580,25 @@
     </mat-form-field>
   </form>
 
-    <div class="example-row">
-      <mat-form-field dense appearance="outline">
-        <mat-label>Enter your password</mat-label>
-        <input matInput [type]="hide ? 'password' : 'text'" />
-        <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
-          <mat-icon dense>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
-        </button>
-      </mat-form-field>
-    </div>
+  <div class="example-row">
+    <mat-form-field dense appearance="outline">
+      <mat-label>Enter your password</mat-label>
+      <input matInput [type]="hide ? 'password' : 'text'" />
+      <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
+        <mat-icon dense>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
+      </button>
+    </mat-form-field>
+  </div>
 
-    <div class="example-row">
-      <mat-form-field dense appearance="outline">
-        <mat-label>Amount</mat-label>
-        <input matInput type="number" value="0" class="example-right-align" />
-        <span matPrefix>$&nbsp;</span>
-        <span matSuffix>.00</span>
-      </mat-form-field>
-    </div>
-    <br />
+  <div class="example-row">
+    <mat-form-field dense appearance="outline">
+      <mat-label>Amount</mat-label>
+      <input matInput type="number" value="0" class="example-right-align" />
+      <span matPrefix>$&nbsp;</span>
+      <span matSuffix>.00</span>
+    </mat-form-field>
+  </div>
+  <br />
 
   <div class="example-row">
     <mat-form-field #ff2 dense appearance="outline">
@@ -717,53 +717,53 @@
   </div>
   <br />
   <h5 class="uxg-h5">Dense Inputs</h5>
-    <div class="example-row">
-      <mat-form-field dense appearance="fill">
-        <mat-label>This is label</mat-label>
-        <input matInput value="this is value" />
-      </mat-form-field>
-    </div>
-    <div class="example-row">
-      <mat-form-field dense appearance="fill">
-        <mat-icon color="primary" matPrefix dense>search</mat-icon>
-        <mat-label>This is label</mat-label>
-        <input matInput value="this is value" />
-      </mat-form-field>
-    </div>
-    <div class="example-row">
-      <mat-form-field dense appearance="fill">
-        <mat-label>Label</mat-label>
-        <input matInput />
-        <mat-hint>Helper text</mat-hint>
-      </mat-form-field>
-    </div>
-    <br />
-    <form class="example-row">
-      <mat-form-field dense floatLabel="never" class="example-full-width" appearance="fill">
-        <mat-icon color="primary" matPrefix dense>search</mat-icon>
-        <mat-label>Search...</mat-label>
-        <input type="search" matInput />
-      </mat-form-field>
-    </form>
+  <div class="example-row">
+    <mat-form-field dense appearance="fill">
+      <mat-label>This is label</mat-label>
+      <input matInput value="this is value" />
+    </mat-form-field>
+  </div>
+  <div class="example-row">
+    <mat-form-field dense appearance="fill">
+      <mat-icon color="primary" matPrefix dense>search</mat-icon>
+      <mat-label>This is label</mat-label>
+      <input matInput value="this is value" />
+    </mat-form-field>
+  </div>
+  <div class="example-row">
+    <mat-form-field dense appearance="fill">
+      <mat-label>Label</mat-label>
+      <input matInput />
+      <mat-hint>Helper text</mat-hint>
+    </mat-form-field>
+  </div>
+  <br />
+  <form class="example-row">
+    <mat-form-field dense floatLabel="never" class="example-full-width" appearance="fill">
+      <mat-icon color="primary" matPrefix dense>search</mat-icon>
+      <mat-label>Search...</mat-label>
+      <input type="search" matInput />
+    </mat-form-field>
+  </form>
 
-    <div class="example-row">
-      <mat-form-field dense appearance="fill">
-        <mat-label>Enter your password</mat-label>
-        <input matInput [type]="hide ? 'password' : 'text'" />
-        <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
-          <mat-icon dense>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
-        </button>
-      </mat-form-field>
-    </div>
-    <div class="example-row">
-      <mat-form-field dense appearance="fill">
-        <mat-label>Amount</mat-label>
-        <input matInput type="number" value="0" class="example-right-align" />
-        <span matPrefix>$&nbsp;</span>
-        <span matSuffix>.00</span>
-      </mat-form-field>
-    </div>
-    <br />
+  <div class="example-row">
+    <mat-form-field dense appearance="fill">
+      <mat-label>Enter your password</mat-label>
+      <input matInput [type]="hide ? 'password' : 'text'" />
+      <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
+        <mat-icon dense>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
+      </button>
+    </mat-form-field>
+  </div>
+  <div class="example-row">
+    <mat-form-field dense appearance="fill">
+      <mat-label>Amount</mat-label>
+      <input matInput type="number" value="0" class="example-right-align" />
+      <span matPrefix>$&nbsp;</span>
+      <span matSuffix>.00</span>
+    </mat-form-field>
+  </div>
+  <br />
 
   <div class="example-row">
     <mat-form-field #ff2 dense appearance="fill">

--- a/apps/angular-test-app/src/app/components/ui-elements-demo/ui-elements-demo.component.html
+++ b/apps/angular-test-app/src/app/components/ui-elements-demo/ui-elements-demo.component.html
@@ -496,12 +496,14 @@
   <div class="example-row">
     <mat-form-field floatLabel="never" appearance="outline">
       <mat-icon color="primary" matPrefix>favorite</mat-icon>
+      <mat-label>Label</mat-label>
       <input matInput placeholder="Placeholder" />
       <mat-icon color="primary" matSuffix>favorite</mat-icon>
     </mat-form-field>
   </div>
   <div class="example-row">
     <mat-form-field floatLabel="never" appearance="outline">
+      <mat-label>Label</mat-label>
       <input matInput placeholder="Placeholder" />
       <mat-hint>Helper text</mat-hint>
     </mat-form-field>
@@ -548,12 +550,14 @@
   <div class="example-container">
     <div class="example-row">
       <mat-form-field dense appearance="outline">
+        <mat-label>This is label</mat-label>
         <input matInput value="this is value" />
       </mat-form-field>
     </div>
     <div class="example-row">
       <mat-form-field dense appearance="outline">
         <mat-icon color="primary" matPrefix dense>search</mat-icon>
+        <mat-label>This is label</mat-label>
         <input matInput value="this is value" />
       </mat-form-field>
     </div>
@@ -665,14 +669,6 @@
     </div>
   </div>
 
-  <br />
-  <h5 class="uxg-h5">Search Input (Legacy)</h5>
-  <div class="example-row">
-    <mat-form-field floatLabel="never" class="example-full-width">
-      <mat-icon color="primary" matPrefix>search</mat-icon>
-      <input type="search" matInput placeholder="Search..." />
-    </mat-form-field>
-  </div>
 </div>
 
 <div>

--- a/apps/angular-test-app/src/app/components/ui-elements-demo/ui-elements-demo.component.html
+++ b/apps/angular-test-app/src/app/components/ui-elements-demo/ui-elements-demo.component.html
@@ -491,8 +491,8 @@
 </div>
 
 <div>
-  <h3 class="uxg-display-3">Inputs</h3>
-  <h5 class="uxg-h5">Fill Input</h5>
+  <h3 class="uxg-h3">Inputs</h3>
+  <h5 class="uxg-h5">Input</h5>
   <div class="example-row">
     <mat-form-field floatLabel="never" appearance="outline">
       <mat-icon color="primary" matPrefix>favorite</mat-icon>
@@ -517,7 +517,7 @@
   </div>
 
   <h5 class="uxg-h5">Input With Icon Button</h5>
-  <div class="example-container" dense>
+  <div class="example-row" dense>
     <mat-form-field appearance="outline">
       <mat-label>Enter your password</mat-label>
       <input matInput [type]="hide ? 'password' : 'text'" />
@@ -526,7 +526,7 @@
       </button>
     </mat-form-field>
   </div>
-  <div>
+  <div class="example-row">
     <mat-form-field appearance="outline">
       <mat-label>Amount</mat-label>
       <input matInput type="number" value="0" class="example-right-align" />
@@ -536,7 +536,7 @@
   </div>
 
   <h5 class="uxg-h5">Error Message</h5>
-  <div class="example-container">
+  <div class="example-row">
     <mat-form-field #ff1 appearance="outline">
       <mat-icon matPrefix>lock_outlined</mat-icon>
       <mat-label>Enter your email</mat-label>
@@ -546,39 +546,41 @@
     </mat-form-field>
   </div>
   <br />
-  <h5 class="uxg-h5">Dense Inputs</h5>
-  <div class="example-container">
-    <div class="example-row">
-      <mat-form-field dense appearance="outline">
-        <mat-label>This is label</mat-label>
-        <input matInput value="this is value" />
-      </mat-form-field>
-    </div>
-    <div class="example-row">
-      <mat-form-field dense appearance="outline">
-        <mat-icon color="primary" matPrefix dense>search</mat-icon>
-        <mat-label>This is label</mat-label>
-        <input matInput value="this is value" />
-      </mat-form-field>
-    </div>
-    <div class="example-row">
-      <mat-form-field dense appearance="outline">
-        <mat-label>Label</mat-label>
-        <input matInput />
-        <mat-hint>Helper text</mat-hint>
-      </mat-form-field>
-    </div>
-    <div>
-      <form class="example-form">
-        <mat-form-field dense floatLabel="never" class="example-full-width" appearance="outline">
-          <mat-icon color="primary" matPrefix dense>search</mat-icon>
-          <mat-label>Search...</mat-label>
-          <input type="search" matInput />
-        </mat-form-field>
-      </form>
-    </div>
 
-    <div>
+  <h5 class="uxg-h5">Dense Inputs</h5>
+  <div class="example-row">
+    <mat-form-field dense appearance="outline">
+      <mat-label>This is label</mat-label>
+      <input matInput value="this is value" />
+    </mat-form-field>
+  </div>
+
+  <div class="example-row">
+    <mat-form-field dense appearance="outline">
+      <mat-icon color="primary" matPrefix dense>search</mat-icon>
+      <mat-label>This is label</mat-label>
+      <input matInput value="this is value" />
+    </mat-form-field>
+  </div>
+
+  <div class="example-row">
+    <mat-form-field dense appearance="outline">
+      <mat-label>Label</mat-label>
+      <input matInput />
+      <mat-hint>Helper text</mat-hint>
+    </mat-form-field>
+  </div>
+  <br />
+
+  <form class="example-row">
+    <mat-form-field dense floatLabel="never" class="example-full-width" appearance="outline">
+      <mat-icon color="primary" matPrefix dense>search</mat-icon>
+      <mat-label>Search...</mat-label>
+      <input type="search" matInput />
+    </mat-form-field>
+  </form>
+
+    <div class="example-row">
       <mat-form-field dense appearance="outline">
         <mat-label>Enter your password</mat-label>
         <input matInput [type]="hide ? 'password' : 'text'" />
@@ -587,7 +589,8 @@
         </button>
       </mat-form-field>
     </div>
-    <div>
+
+    <div class="example-row">
       <mat-form-field dense appearance="outline">
         <mat-label>Amount</mat-label>
         <input matInput type="number" value="0" class="example-right-align" />
@@ -595,9 +598,9 @@
         <span matSuffix>.00</span>
       </mat-form-field>
     </div>
-  </div>
+    <br />
 
-  <div class="example-container">
+  <div class="example-row">
     <mat-form-field #ff2 dense appearance="outline">
       <mat-icon matPrefix dense>lock_outlined</mat-icon>
       <mat-label>Enter your email</mat-label>
@@ -613,19 +616,6 @@
     <div>
       <mat-form-field appearance="outline">
         <mat-label>Font size</mat-label>
-        <mat-select value="16px">
-          <mat-option value="10px">10px</mat-option>
-          <mat-option value="12px">12px</mat-option>
-          <mat-option value="14px">14px</mat-option>
-          <mat-option value="16px">16px</mat-option>
-          <mat-option value="18px">18px</mat-option>
-          <mat-option value="20px">20px</mat-option>
-        </mat-select>
-      </mat-form-field>
-    </div>
-    <div>
-      <p class="uxg-body-3">No label</p>
-      <mat-form-field appearance="outline">
         <mat-select value="16px">
           <mat-option value="10px">10px</mat-option>
           <mat-option value="12px">12px</mat-option>
@@ -671,8 +661,186 @@
 </div>
 
 <div>
+  <h3 class="uxg-h3">Filled Inputs (deprecated)</h3>
+  <h5 class="uxg-h5">Fill Input</h5>
+  <div class="example-row">
+    <mat-form-field floatLabel="never" appearance="fill">
+      <mat-icon color="primary" matPrefix>favorite</mat-icon>
+      <mat-label>Label</mat-label>
+      <input matInput placeholder="Placeholder" />
+      <mat-icon color="primary" matSuffix>favorite</mat-icon>
+    </mat-form-field>
+  </div>
+  <div class="example-row">
+    <mat-form-field floatLabel="never" appearance="fill">
+      <mat-label>Label</mat-label>
+      <input matInput placeholder="Placeholder" />
+      <mat-hint>Helper text</mat-hint>
+    </mat-form-field>
+  </div>
+  <div class="example-row">
+    <mat-form-field floatLabel="never" class="example-full-width" appearance="fill">
+      <mat-icon color="primary" matPrefix>search</mat-icon>
+      <mat-label>Search...</mat-label>
+      <input type="search" matInput />
+    </mat-form-field>
+  </div>
+
+  <h5 class="uxg-h5">Input With Icon Button</h5>
+  <div class="example-row" dense>
+    <mat-form-field appearance="fill">
+      <mat-label>Enter your password</mat-label>
+      <input matInput [type]="hide ? 'password' : 'text'" />
+      <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
+        <mat-icon>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
+      </button>
+    </mat-form-field>
+  </div>
+  <div class="example-row">
+    <mat-form-field appearance="fill">
+      <mat-label>Amount</mat-label>
+      <input matInput type="number" value="0" class="example-right-align" />
+      <span matPrefix>$&nbsp;</span>
+      <span matSuffix>.00</span>
+    </mat-form-field>
+  </div>
+
+  <h5 class="uxg-h5">Error Message</h5>
+  <div class="example-row">
+    <mat-form-field #ff1 appearance="fill">
+      <mat-icon matPrefix>lock_outlined</mat-icon>
+      <mat-label>Enter your email</mat-label>
+      <input matInput placeholder="pat@example.com" [formControl]="email" required />
+      <mat-icon matSuffix [ngClass]="{ 'mat-warn': ff1._control.errorState }">error_outlined</mat-icon>
+      <mat-error *ngIf="email.invalid">{{ getErrorMessage() }}</mat-error>
+    </mat-form-field>
+  </div>
+  <br />
+  <h5 class="uxg-h5">Dense Inputs</h5>
+    <div class="example-row">
+      <mat-form-field dense appearance="fill">
+        <mat-label>This is label</mat-label>
+        <input matInput value="this is value" />
+      </mat-form-field>
+    </div>
+    <div class="example-row">
+      <mat-form-field dense appearance="fill">
+        <mat-icon color="primary" matPrefix dense>search</mat-icon>
+        <mat-label>This is label</mat-label>
+        <input matInput value="this is value" />
+      </mat-form-field>
+    </div>
+    <div class="example-row">
+      <mat-form-field dense appearance="fill">
+        <mat-label>Label</mat-label>
+        <input matInput />
+        <mat-hint>Helper text</mat-hint>
+      </mat-form-field>
+    </div>
+    <br />
+    <form class="example-row">
+      <mat-form-field dense floatLabel="never" class="example-full-width" appearance="fill">
+        <mat-icon color="primary" matPrefix dense>search</mat-icon>
+        <mat-label>Search...</mat-label>
+        <input type="search" matInput />
+      </mat-form-field>
+    </form>
+
+    <div class="example-row">
+      <mat-form-field dense appearance="fill">
+        <mat-label>Enter your password</mat-label>
+        <input matInput [type]="hide ? 'password' : 'text'" />
+        <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
+          <mat-icon dense>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
+        </button>
+      </mat-form-field>
+    </div>
+    <div class="example-row">
+      <mat-form-field dense appearance="fill">
+        <mat-label>Amount</mat-label>
+        <input matInput type="number" value="0" class="example-right-align" />
+        <span matPrefix>$&nbsp;</span>
+        <span matSuffix>.00</span>
+      </mat-form-field>
+    </div>
+    <br />
+
+  <div class="example-row">
+    <mat-form-field #ff2 dense appearance="fill">
+      <mat-icon matPrefix dense>lock_outlined</mat-icon>
+      <mat-label>Enter your email</mat-label>
+      <input matInput placeholder="pat@example.com" [formControl]="email" required />
+      <mat-icon matSuffix dense [ngClass]="{ 'mat-warn': ff2._control.errorState }">error_outlined</mat-icon>
+      <mat-error *ngIf="email.invalid">{{ getErrorMessage() }}</mat-error>
+    </mat-form-field>
+  </div>
+
+  <br />
+  <h5 class="uxg-h5">Select</h5>
+  <div class="example-row">
+    <div>
+      <mat-form-field appearance="fill">
+        <mat-label>Font size</mat-label>
+        <mat-select value="16px">
+          <mat-option value="10px">10px</mat-option>
+          <mat-option value="12px">12px</mat-option>
+          <mat-option value="14px">14px</mat-option>
+          <mat-option value="16px">16px</mat-option>
+          <mat-option value="18px">18px</mat-option>
+          <mat-option value="20px">20px</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div>
+      <p class="uxg-body-3">No label</p>
+      <mat-form-field appearance="fill">
+        <mat-select value="16px">
+          <mat-option value="10px">10px</mat-option>
+          <mat-option value="12px">12px</mat-option>
+          <mat-option value="14px">14px</mat-option>
+          <mat-option value="16px">16px</mat-option>
+          <mat-option value="18px">18px</mat-option>
+          <mat-option value="20px">20px</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </div>
+
+  <h5 class="uxg-h5">Dense select</h5>
+  <div class="example-row">
+    <div>
+      <mat-form-field appearance="fill" dense>
+        <mat-label>Font size</mat-label>
+        <mat-select value="16px">
+          <mat-option value="10px">10px</mat-option>
+          <mat-option value="12px">12px</mat-option>
+          <mat-option value="14px">14px</mat-option>
+          <mat-option value="16px">16px</mat-option>
+          <mat-option value="18px">18px</mat-option>
+          <mat-option value="20px">20px</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div>
+      <p class="uxg-body-3">Multi-select, no default value</p>
+      <mat-form-field appearance="fill" dense>
+        <mat-label> Colors </mat-label>
+        <mat-select multiple>
+          <mat-option value="Violet">Violet</mat-option>
+          <mat-option value="Fuchsia">Fuchsia</mat-option>
+          <mat-option value="Crimson">Crimson</mat-option>
+          <mat-option value="Grass">Grass</mat-option>
+          <mat-option value="Ocean">Ocean</mat-option>
+          <mat-option value="Gold">Gold</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </div>
+</div>
+
+<div>
   <div>
-    <h3 class="uxg-display-3">Expansion</h3>
+    <h3 class="uxg-h3">Expansion</h3>
     <h5 class="uxg-h5">Expansion filter</h5>
     <div class="example-row">
       <mat-expansion-panel class="uxg-expansion-filter">

--- a/themes/angular-theme/lib/form-field/_form-field-base.scss
+++ b/themes/angular-theme/lib/form-field/_form-field-base.scss
@@ -15,6 +15,42 @@ $infix-border-top-dense: 0.661em;
 $infix-top-no-label: -0.35em;
 $infix-padding-bottom-no-label: 0.469em;
 
+.mat-form-field-appearance-outline {
+  .mat-form-field-wrapper {
+    .mat-form-field-infix {
+      padding: 0.95em 0 0.95em 0;
+    }
+  }
+  
+  &.mat-focused {
+    .mat-form-field-outline-thick {
+      .mat-form-field-outline-start.mat-form-field-outline-start,
+      .mat-form-field-outline-end.mat-form-field-outline-end {
+        border-width: 2px;
+      }
+    }
+  }
+
+  .mat-form-field-outline-thick {
+    .mat-form-field-outline-start.mat-form-field-outline-start,
+    .mat-form-field-outline-end.mat-form-field-outline-end {
+      border-width: 1px;
+    }
+  }
+
+  .mat-form-field-outline {
+    border-radius: 6px;
+
+    .mat-form-field-outline-gap {
+      display: none;
+    }
+  }
+
+  &.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label.mat-form-field-label {
+    transform: translateY(-1em) scale(0.75);
+  }
+}
+
 .mat-form-field-appearance-legacy {
   .mat-form-field-flex {
     align-items: flex-end;

--- a/themes/angular-theme/lib/form-field/_form-field-base.scss
+++ b/themes/angular-theme/lib/form-field/_form-field-base.scss
@@ -17,8 +17,14 @@ $infix-padding-bottom-no-label: 0.469em;
 
 .mat-form-field-appearance-outline {
   .mat-form-field-wrapper {
+    .mat-form-field-flex {
+      padding: 0 1em 0 1em;
+    }
+    .mat-form-field-prefix {
+      padding-right: 0.5em;
+    }
     .mat-form-field-infix {
-      padding: 0.95em 0 0.95em 0;
+      padding: 1.2em 0 0.7em 0;
     }
   }
   
@@ -38,6 +44,11 @@ $infix-padding-bottom-no-label: 0.469em;
     }
   }
 
+  .mat-form-field-prefix.mat-form-field-prefix,
+  .mat-form-field-suffix.mat-form-field-suffix {
+    top: -0.1em;
+  }
+
   .mat-form-field-outline {
     border-radius: 6px;
 
@@ -47,7 +58,11 @@ $infix-padding-bottom-no-label: 0.469em;
   }
 
   &.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label.mat-form-field-label {
-    transform: translateY(-1em) scale(0.75);
+    transform: translateY(-0.6em) scale(0.8);
+  }
+
+  .mat-form-field-subscript-wrapper {
+    margin-top: 0;
   }
 }
 

--- a/themes/angular-theme/lib/form-field/_form-field-theme.scss
+++ b/themes/angular-theme/lib/form-field/_form-field-theme.scss
@@ -5,8 +5,31 @@
 @mixin theme($theme) {
   $primary: map.get($theme, primary);
   $error: map.get($theme, error);
+  $background: map-get($theme, background);
   $fill-background: palette.get-color-from-palette($primary, default, 0.08);
   $error-background: palette.get-color-from-palette($error, default, 0.04);
+
+
+  .mat-form-field-appearance-outline {
+    .mat-form-field-outline {
+      background-color: map.get($background, card);
+    }
+
+    &.mat-focused {
+      .mat-form-field-outline {
+        background-color: $fill-background;
+      }
+
+      &.mat-focused.mat-form-field-invalid {
+        .mat-form-field-outline {
+          background-color: $error-background;
+        }
+      }
+    }
+    &.mat-form-field-invalid.mat-form-field-invalid .mat-form-field-outline-thick {
+      color: map.get($error, default);
+    }
+  }
 
   .mat-form-field-appearance-fill {
     .mat-form-field-flex {
@@ -46,6 +69,12 @@
 }
 
 @mixin typography($config) {
+  .mat-form-field-appearance-outline {
+    .mat-input-element {
+      @include mat.typography-level($config, subtitle-2);
+    }
+    @include mat.typography-level($config, body-2);
+  }
   .mat-form-field-appearance-fill {
     @include mat.typography-level($config, subtitle-1);
 

--- a/themes/angular-theme/lib/form-field/_form-field-theme.scss
+++ b/themes/angular-theme/lib/form-field/_form-field-theme.scss
@@ -70,8 +70,21 @@
 
 @mixin typography($config) {
   .mat-form-field-appearance-outline {
+    &[dense] {
+      .mat-input-element {
+        @include mat.typography-level($config, subtitle-3);
+      }
+      .mat-input-element::placeholder {
+        @include mat.typography-level($config, body-3);
+      }
+      @include mat.typography-level($config, body-3);
+    }
+
     .mat-input-element {
       @include mat.typography-level($config, subtitle-2);
+    }
+    .mat-input-element::placeholder {
+      @include mat.typography-level($config, body-2);
     }
     @include mat.typography-level($config, body-2);
   }


### PR DESCRIPTION
Only adding text field: label inside, normal and dense sizes.

![image](https://user-images.githubusercontent.com/371041/194308065-e62570ae-6dd5-4cbc-8f61-176d3bdc0314.png)

Should not affect v1 "fill" appearance, developers needs to opt-in by specifying `appearance="outline"`