### PR TITLE
fix(form-field): error background too large for appearance outline

### DIFF
--- a/themes/angular-theme/lib/form-field/_form-field-theme.scss
+++ b/themes/angular-theme/lib/form-field/_form-field-theme.scss
@@ -43,13 +43,15 @@
     .mat-form-field-ripple {
       background-color: map.get($primary, default);
     }
+
+    &.mat-form-field-invalid {
+      .mat-form-field-flex {
+        background-color: $error-background;
+      }
+    }
   }
 
   .mat-form-field.mat-form-field-invalid {
-    .mat-form-field-flex {
-      background-color: $error-background;
-    }
-
     .mat-input-element {
       caret-color: map.get($error, default);
     }


### PR DESCRIPTION
see error background going outside the outlined border on the top side of the textfield:

![image](https://user-images.githubusercontent.com/371041/195384052-18824764-7520-44ff-b702-a608aec4b2ab.png)
