### PR TITLE
feat(theme): move elevation as dependency

### DIFF
--- a/libs/web-components/global-nav/README.md
+++ b/libs/web-components/global-nav/README.md
@@ -11,5 +11,5 @@ The Global Navigation ensures a consistant navigation between different apps and
 This pattern requires the following web components to be installed:
 
 ```
-npm i @finastra/app-bar @finastra/brand-card @finastra/button @finastra/fds-theme @finastra/launchpad @finastra/sidenav @finastra/user-profile @material/mwc-drawer @finastra/icon-button
+npm i @finastra/app-bar @finastra/brand-card @finastra/button @finastra/fds-theme @finastra/launchpad @finastra/sidenav @finastra/user-profile @finastra/icon-button
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -58803,7 +58803,7 @@
     },
     "themes/angular-theme": {
       "name": "@finastra/angular-theme",
-      "version": "3.6.0",
+      "version": "3.7.1",
       "license": "MIT",
       "peerDependencies": {
         "@angular/material": "^14.1.0"
@@ -58813,11 +58813,11 @@
       "name": "@finastra/fds-theme",
       "version": "1.0.2",
       "license": "MIT",
+      "dependencies": {
+        "@material/elevation": "^13.0.0"
+      },
       "devDependencies": {
         "sass": "1.33.0"
-      },
-      "peerDependencies": {
-        "@material/elevation": "^13.0.0"
       }
     },
     "themes/fds-theme/node_modules/sass": {
@@ -61600,6 +61600,7 @@
     "@finastra/fds-theme": {
       "version": "file:themes/fds-theme",
       "requires": {
+        "@material/elevation": "^13.0.0",
         "sass": "1.33.0"
       },
       "dependencies": {

--- a/themes/fds-theme/package.json
+++ b/themes/fds-theme/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "sass": "1.33.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@material/elevation": "^13.0.0"
   },
   "scripts": {


### PR DESCRIPTION
1. remove `npm i @material/mwc-drawer` from global-nav readme since it already installs `@finastra/sidenav`
2. move `@material/elevation` as a dependency instead of peerDependency from `@finastra/fds-theme`