### PR TITLE
feat(storybook): Remove already present API doc from storybook "Docs" tab

### DIFF
--- a/libs/web-components/README.md
+++ b/libs/web-components/README.md
@@ -232,6 +232,7 @@ const README = require('../README.md');
 import { AppBar } from '@finastra/app-bar';
 import { Meta, Story } from '@storybook/web-components';
 import { actions, argTypes, cssprops } from './sb-generated/fds-app-bar.json';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 
 export default {
   title: 'NAVIGATION/App Bar',
@@ -243,7 +244,7 @@ export default {
   parameters: {
     actions,
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     cssprops
   },

--- a/libs/web-components/README.md
+++ b/libs/web-components/README.md
@@ -243,7 +243,7 @@ export default {
   parameters: {
     actions,
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     cssprops
   },

--- a/libs/web-components/account-card/README.md
+++ b/libs/web-components/account-card/README.md
@@ -23,7 +23,7 @@ import '@finastra/account-card';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/account-card/stories/account-card.stories.ts
+++ b/libs/web-components/account-card/stories/account-card.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/account-card';
 import type { AccountCard } from '@finastra/account-card';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-account-card.json';
 
 export default {
@@ -17,7 +18,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/account-card/stories/account-card.stories.ts
+++ b/libs/web-components/account-card/stories/account-card.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/account-card';
 import type { AccountCard } from '@finastra/account-card';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-account-card.json';
 
 export default {
@@ -18,7 +18,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/alert-message/README.md
+++ b/libs/web-components/alert-message/README.md
@@ -22,7 +22,7 @@ import '@finastra/alert-message';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/alert-message/stories/alert-message.stories.ts
+++ b/libs/web-components/alert-message/stories/alert-message.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/alert-message';
 import { AlertMessage, ALERT_LAYOUT } from '@finastra/alert-message';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-alert-message.json';
 
 export default {
@@ -15,7 +15,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     }
   },
   cssprops

--- a/libs/web-components/alert-message/stories/alert-message.stories.ts
+++ b/libs/web-components/alert-message/stories/alert-message.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/alert-message';
 import { AlertMessage, ALERT_LAYOUT } from '@finastra/alert-message';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-alert-message.json';
 
 export default {
@@ -14,7 +15,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     }
   },
   cssprops

--- a/libs/web-components/app-bar/README.md
+++ b/libs/web-components/app-bar/README.md
@@ -26,7 +26,7 @@ import '@finastra/app-bar';
 </fds-app-bar>
 ```
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/app-bar/stories/app-bar.stories.ts
+++ b/libs/web-components/app-bar/stories/app-bar.stories.ts
@@ -5,7 +5,7 @@ import '@finastra/button';
 import '@finastra/user-profile';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { actions, argTypes, cssprops } from './sb-generated/fds-app-bar.json';
 
 export default {
@@ -18,7 +18,7 @@ export default {
   parameters: {
     actions,
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/app-bar/stories/app-bar.stories.ts
+++ b/libs/web-components/app-bar/stories/app-bar.stories.ts
@@ -5,6 +5,7 @@ import '@finastra/button';
 import '@finastra/user-profile';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { actions, argTypes, cssprops } from './sb-generated/fds-app-bar.json';
 
 export default {
@@ -17,7 +18,7 @@ export default {
   parameters: {
     actions,
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/app-card/README.md
+++ b/libs/web-components/app-card/README.md
@@ -37,7 +37,7 @@ import '@finastra/app-card';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/app-card/stories/app-card.stories.ts
+++ b/libs/web-components/app-card/stories/app-card.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/app-card';
 import type { AppCard } from '@finastra/app-card';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-app-card.json';
 
 const dummyApp = {
@@ -20,7 +20,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/app-card/stories/app-card.stories.ts
+++ b/libs/web-components/app-card/stories/app-card.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/app-card';
 import type { AppCard } from '@finastra/app-card';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-app-card.json';
 
 const dummyApp = {
@@ -19,7 +20,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/autocomplete/README.md
+++ b/libs/web-components/autocomplete/README.md
@@ -26,7 +26,7 @@ import '@finastra/autocomplete';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/autocomplete/stories/autocomplete.stories.ts
+++ b/libs/web-components/autocomplete/stories/autocomplete.stories.ts
@@ -4,7 +4,7 @@ import '@finastra/list';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-autocomplete.json';
 
 export default {
@@ -17,7 +17,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     cssprops
   }

--- a/libs/web-components/autocomplete/stories/autocomplete.stories.ts
+++ b/libs/web-components/autocomplete/stories/autocomplete.stories.ts
@@ -4,6 +4,7 @@ import '@finastra/list';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-autocomplete.json';
 
 export default {
@@ -16,7 +17,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     cssprops
   }

--- a/libs/web-components/avatar/README.md
+++ b/libs/web-components/avatar/README.md
@@ -22,7 +22,7 @@ import '@finastra/avatar';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/avatar/stories/avatar.stories.ts
+++ b/libs/web-components/avatar/stories/avatar.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/avatar';
 import { Avatar } from '@finastra/avatar';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-avatar.json';
 
 export default {
@@ -12,7 +13,7 @@ export default {
   args: {},
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/avatar/stories/avatar.stories.ts
+++ b/libs/web-components/avatar/stories/avatar.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/avatar';
 import { Avatar } from '@finastra/avatar';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-avatar.json';
 
 export default {
@@ -13,7 +13,7 @@ export default {
   args: {},
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/badge/README.md
+++ b/libs/web-components/badge/README.md
@@ -24,7 +24,7 @@ import '@finastra/badge';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/badge/stories/badge.stories.ts
+++ b/libs/web-components/badge/stories/badge.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/badge';
 import { Badge } from '@finastra/badge';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { COLOR, POSITION, TYPE } from '../src/badge.interface';
 import { argTypes } from "./sb-generated/fds-badge.json";
 
@@ -19,7 +19,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     }
   },
   decorators: [

--- a/libs/web-components/badge/stories/badge.stories.ts
+++ b/libs/web-components/badge/stories/badge.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/badge';
 import { Badge } from '@finastra/badge';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { COLOR, POSITION, TYPE } from '../src/badge.interface';
 import { argTypes } from "./sb-generated/fds-badge.json";
 
@@ -18,7 +19,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     }
   },
   decorators: [

--- a/libs/web-components/brand-card/README.md
+++ b/libs/web-components/brand-card/README.md
@@ -22,7 +22,7 @@ import '@finastra/brand-card';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/brand-card/stories/brand-card.stories.ts
+++ b/libs/web-components/brand-card/stories/brand-card.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/brand-card';
 import { BrandCard } from '@finastra/brand-card';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-brand-card.json';
 
 export default {
@@ -18,7 +19,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/brand-card/stories/brand-card.stories.ts
+++ b/libs/web-components/brand-card/stories/brand-card.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/brand-card';
 import { BrandCard } from '@finastra/brand-card';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-brand-card.json';
 
 export default {
@@ -19,7 +19,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/breadcrumb/README.md
+++ b/libs/web-components/breadcrumb/README.md
@@ -20,7 +20,7 @@ import '@finastra/breadcrumb';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/breadcrumb/stories/breadcrumb.stories.ts
+++ b/libs/web-components/breadcrumb/stories/breadcrumb.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/breadcrumb';
 import type { Breadcrumb } from '@finastra/breadcrumb';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-breadcrumb.json';
 
 export default {
@@ -18,7 +18,7 @@ export default {
       handles: ['selected']
     },
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     cssprops
   },

--- a/libs/web-components/breadcrumb/stories/breadcrumb.stories.ts
+++ b/libs/web-components/breadcrumb/stories/breadcrumb.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/breadcrumb';
 import type { Breadcrumb } from '@finastra/breadcrumb';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-breadcrumb.json';
 
 export default {
@@ -17,7 +18,7 @@ export default {
       handles: ['selected']
     },
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     cssprops
   },

--- a/libs/web-components/button-toggle-group/README.md
+++ b/libs/web-components/button-toggle-group/README.md
@@ -26,7 +26,7 @@ import '@finastra/button-toggle-group';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Attributes
 

--- a/libs/web-components/button-toggle-group/stories/button-toggle-group.stories.ts
+++ b/libs/web-components/button-toggle-group/stories/button-toggle-group.stories.ts
@@ -2,6 +2,7 @@ const README = require('../README.md');
 import '@finastra/button-toggle-group';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-button-toggle-group.json';
 
 export default {
@@ -10,7 +11,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     cssprops,
     design: {

--- a/libs/web-components/button-toggle-group/stories/button-toggle-group.stories.ts
+++ b/libs/web-components/button-toggle-group/stories/button-toggle-group.stories.ts
@@ -2,7 +2,7 @@ const README = require('../README.md');
 import '@finastra/button-toggle-group';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-button-toggle-group.json';
 
 export default {
@@ -11,7 +11,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     cssprops,
     design: {

--- a/libs/web-components/button/README.md
+++ b/libs/web-components/button/README.md
@@ -22,7 +22,7 @@ import '@finastra/button';
 <fds-text-button label="Text button"></fds-text-button>
 ```
 
-### Documentation
+### API
 
 ### Button
 

--- a/libs/web-components/button/stories/contained-button.stories.ts
+++ b/libs/web-components/button/stories/contained-button.stories.ts
@@ -4,6 +4,7 @@ import type { ContainedButton } from '@finastra/button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-button.json';
 
 export default {
@@ -13,7 +14,7 @@ export default {
   args: {},
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/button/stories/contained-button.stories.ts
+++ b/libs/web-components/button/stories/contained-button.stories.ts
@@ -4,7 +4,7 @@ import type { ContainedButton } from '@finastra/button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-button.json';
 
 export default {
@@ -14,7 +14,7 @@ export default {
   args: {},
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/button/stories/outlined-button.stories.ts
+++ b/libs/web-components/button/stories/outlined-button.stories.ts
@@ -4,6 +4,7 @@ import { OutlinedButton } from '@finastra/button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-outlined-button.json';
 
 export default {
@@ -13,7 +14,7 @@ export default {
   args: {},
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/button/stories/outlined-button.stories.ts
+++ b/libs/web-components/button/stories/outlined-button.stories.ts
@@ -4,7 +4,7 @@ import { OutlinedButton } from '@finastra/button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-outlined-button.json';
 
 export default {
@@ -14,7 +14,7 @@ export default {
   args: {},
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/button/stories/text-button.stories.ts
+++ b/libs/web-components/button/stories/text-button.stories.ts
@@ -4,7 +4,7 @@ import { TextButton } from '@finastra/button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-text-button.json';
 
 export default {
@@ -14,7 +14,7 @@ export default {
   args: {},
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/button/stories/text-button.stories.ts
+++ b/libs/web-components/button/stories/text-button.stories.ts
@@ -4,6 +4,7 @@ import { TextButton } from '@finastra/button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-text-button.json';
 
 export default {
@@ -13,7 +14,7 @@ export default {
   args: {},
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/card/README.md
+++ b/libs/web-components/card/README.md
@@ -56,7 +56,7 @@ import '@finastra/card';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/card/stories/card.stories.ts
+++ b/libs/web-components/card/stories/card.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/card';
 import type { Card } from '@finastra/card';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-card.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/card/stories/card.stories.ts
+++ b/libs/web-components/card/stories/card.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/card';
 import type { Card } from '@finastra/card';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-card.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/charts/README.md
+++ b/libs/web-components/charts/README.md
@@ -25,7 +25,7 @@ import '@finastra/charts';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/charts/stories/donut-charts.stories.ts
+++ b/libs/web-components/charts/stories/donut-charts.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/charts';
 import type { DonutChart } from '@finastra/charts/';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes } from './sb-generated/fds-donut-chart.json';
 const demoData = [28, 20, 15, 9, 10, 10, 20]
 const demoLabels = ['Housing', 'Daily spending', 'Taxes', 'Other savings', 'Retirement', 'Insurance', 'Debt']
@@ -21,7 +21,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/charts/stories/donut-charts.stories.ts
+++ b/libs/web-components/charts/stories/donut-charts.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/charts';
 import type { DonutChart } from '@finastra/charts/';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes } from './sb-generated/fds-donut-chart.json';
 const demoData = [28, 20, 15, 9, 10, 10, 20]
 const demoLabels = ['Housing', 'Daily spending', 'Taxes', 'Other savings', 'Retirement', 'Insurance', 'Debt']
@@ -20,7 +21,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/charts/stories/pie-charts.stories.ts
+++ b/libs/web-components/charts/stories/pie-charts.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/charts';
 import type { PieChart } from '@finastra/charts/';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 const demoData = [28, 20, 15, 9, 10, 10, 20];
 const demoLabels = ['Housing', 'Daily spending', 'Taxes', 'Other savings', 'Retirement', 'Insurance', 'Debt'];
 
@@ -99,7 +99,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/charts/stories/pie-charts.stories.ts
+++ b/libs/web-components/charts/stories/pie-charts.stories.ts
@@ -3,8 +3,9 @@ import '@finastra/charts';
 import type { PieChart } from '@finastra/charts/';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-const demoData = [28, 20, 15, 9, 10, 10, 20]
-const demoLabels = ['Housing', 'Daily spending', 'Taxes', 'Other savings', 'Retirement', 'Insurance', 'Debt']
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+const demoData = [28, 20, 15, 9, 10, 10, 20];
+const demoLabels = ['Housing', 'Daily spending', 'Taxes', 'Other savings', 'Retirement', 'Insurance', 'Debt'];
 
 export default {
   title: 'DATA DISPLAY/Charts/Pie Chart',
@@ -98,7 +99,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/charts/stories/radial-bar-charts.stories.ts
+++ b/libs/web-components/charts/stories/radial-bar-charts.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/charts';
 import type { RadialBarChart } from '@finastra/charts/';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-radial-bar-chart.json';
 
 export default {
@@ -27,7 +27,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/charts/stories/radial-bar-charts.stories.ts
+++ b/libs/web-components/charts/stories/radial-bar-charts.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/charts';
 import type { RadialBarChart } from '@finastra/charts/';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-radial-bar-chart.json';
 
 export default {
@@ -26,7 +27,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/checkbox/README.md
+++ b/libs/web-components/checkbox/README.md
@@ -21,7 +21,7 @@ import '@finastra/checkbox';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/checkbox/stories/checkbox.stories.ts
+++ b/libs/web-components/checkbox/stories/checkbox.stories.ts
@@ -2,6 +2,7 @@ const README = require('../README.md');
 import '@finastra/checkbox';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-checkbox.json';
 
 export default {
@@ -15,7 +16,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/checkbox/stories/checkbox.stories.ts
+++ b/libs/web-components/checkbox/stories/checkbox.stories.ts
@@ -2,7 +2,7 @@ const README = require('../README.md');
 import '@finastra/checkbox';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-checkbox.json';
 
 export default {
@@ -16,7 +16,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/chip/README.md
+++ b/libs/web-components/chip/README.md
@@ -22,7 +22,7 @@ import '@finastra/chip';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/chip/stories/chip.stories.ts
+++ b/libs/web-components/chip/stories/chip.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/chip';
 import type { Chip } from '@finastra/chip';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-chip.json';
 
 export default {
@@ -17,7 +17,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/chip/stories/chip.stories.ts
+++ b/libs/web-components/chip/stories/chip.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/chip';
 import type { Chip } from '@finastra/chip';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-chip.json';
 
 export default {
@@ -16,7 +17,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/circular-progress/README.md
+++ b/libs/web-components/circular-progress/README.md
@@ -21,7 +21,7 @@ import '@finastra/circular-progress';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/circular-progress/stories/circular-progress.stories.ts
+++ b/libs/web-components/circular-progress/stories/circular-progress.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/circular-progress';
 import type { CircularProgress } from '@finastra/circular-progress';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-circular-progress.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/circular-progress/stories/circular-progress.stories.ts
+++ b/libs/web-components/circular-progress/stories/circular-progress.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/circular-progress';
 import type { CircularProgress } from '@finastra/circular-progress';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-circular-progress.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/data-table/stories/data-table-pagination.stories.ts
+++ b/libs/web-components/data-table/stories/data-table-pagination.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/data-table';
 import { DataTablePagination } from '@finastra/data-table';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { PAGINATION_EVENTS } from '../src/constants';
 
 const demoLength = 11;
@@ -83,7 +84,7 @@ export default {
       handles: [PAGINATION_EVENTS.PAGINATION_CHANGED]
     },
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/data-table/stories/data-table-pagination.stories.ts
+++ b/libs/web-components/data-table/stories/data-table-pagination.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/data-table';
 import { DataTablePagination } from '@finastra/data-table';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { PAGINATION_EVENTS } from '../src/constants';
 
 const demoLength = 11;
@@ -84,7 +84,7 @@ export default {
       handles: [PAGINATION_EVENTS.PAGINATION_CHANGED]
     },
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/data-table/stories/data-table-with-pagination.stories.ts
+++ b/libs/web-components/data-table/stories/data-table-with-pagination.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/data-table';
 import { DataTableWithPagination } from '@finastra/data-table';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { columns, columnsToDisplay, ELEMENT_DATA } from './data';
 import { actions } from "./sb-generated/fds-data-table-with-pagination.json";
 
@@ -125,7 +125,7 @@ export default {
   parameters: {
     actions,
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/data-table/stories/data-table-with-pagination.stories.ts
+++ b/libs/web-components/data-table/stories/data-table-with-pagination.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/data-table';
 import { DataTableWithPagination } from '@finastra/data-table';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { columns, columnsToDisplay, ELEMENT_DATA } from './data';
 import { actions } from "./sb-generated/fds-data-table-with-pagination.json";
 
@@ -124,7 +125,7 @@ export default {
   parameters: {
     actions,
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/data-table/stories/data-table.stories.ts
+++ b/libs/web-components/data-table/stories/data-table.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/data-table';
 import { DataTable } from '@finastra/data-table';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { columns, columnsToDisplay, ELEMENT_DATA } from './data';
 import { actions } from './sb-generated/fds-data-table.json';
 
@@ -99,7 +100,7 @@ export default {
   parameters: {
     actions,
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/data-table/stories/data-table.stories.ts
+++ b/libs/web-components/data-table/stories/data-table.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/data-table';
 import { DataTable } from '@finastra/data-table';
 import { Story } from '@storybook/web-components';
 import { html } from 'lit';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { columns, columnsToDisplay, ELEMENT_DATA } from './data';
 import { actions } from './sb-generated/fds-data-table.json';
 
@@ -100,7 +100,7 @@ export default {
   parameters: {
     actions,
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/dialog/README.md
+++ b/libs/web-components/dialog/README.md
@@ -42,7 +42,7 @@ import '@finastra/dialog';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/dialog/stories/dialog.stories.ts
+++ b/libs/web-components/dialog/stories/dialog.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/dialog';
 import type { Dialog } from '@finastra/dialog';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from "./sb-generated/fds-dialog.json";
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     cssprops
   },

--- a/libs/web-components/dialog/stories/dialog.stories.ts
+++ b/libs/web-components/dialog/stories/dialog.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/dialog';
 import type { Dialog } from '@finastra/dialog';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from "./sb-generated/fds-dialog.json";
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     cssprops
   },

--- a/libs/web-components/divider/README.md
+++ b/libs/web-components/divider/README.md
@@ -21,7 +21,7 @@ import '@finastra/divider';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/divider/stories/divider.stories.ts
+++ b/libs/web-components/divider/stories/divider.stories.ts
@@ -4,7 +4,7 @@ import { Divider } from '@finastra/divider';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-divider.json';
 
 export default {
@@ -14,7 +14,7 @@ export default {
   args: {},
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     cssprops,
     design: {

--- a/libs/web-components/divider/stories/divider.stories.ts
+++ b/libs/web-components/divider/stories/divider.stories.ts
@@ -4,6 +4,7 @@ import { Divider } from '@finastra/divider';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-divider.json';
 
 export default {
@@ -13,7 +14,7 @@ export default {
   args: {},
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     cssprops,
     design: {

--- a/libs/web-components/expansion-panel/README.md
+++ b/libs/web-components/expansion-panel/README.md
@@ -45,7 +45,7 @@ import '@finastra/expansion-panel';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/expansion-panel/stories/expansion-panel.stories.ts
+++ b/libs/web-components/expansion-panel/stories/expansion-panel.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/expansion-panel';
 import type { ExpansionPanel } from '@finastra/expansion-panel';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-expansion-panel.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     cssprops
   },

--- a/libs/web-components/expansion-panel/stories/expansion-panel.stories.ts
+++ b/libs/web-components/expansion-panel/stories/expansion-panel.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/expansion-panel';
 import type { ExpansionPanel } from '@finastra/expansion-panel';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-expansion-panel.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     cssprops
   },

--- a/libs/web-components/fab/README.md
+++ b/libs/web-components/fab/README.md
@@ -21,7 +21,7 @@ import '@finastra/fab';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/fab/stories/fab.stories.ts
+++ b/libs/web-components/fab/stories/fab.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/fab';
 import type { Fab } from '@finastra/fab';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-fab.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/fab/stories/fab.stories.ts
+++ b/libs/web-components/fab/stories/fab.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/fab';
 import type { Fab } from '@finastra/fab';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-fab.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/filter-tree/README.md
+++ b/libs/web-components/filter-tree/README.md
@@ -41,7 +41,7 @@ import '@finastra/filter-tree';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/filter-tree/stories/filter-tree.stories.ts
+++ b/libs/web-components/filter-tree/stories/filter-tree.stories.ts
@@ -3,7 +3,9 @@ import '@finastra/filter-tree';
 import type { FilterTree } from '@finastra/filter-tree';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-filter-tree.json';
+
 const demoData = [
   {
     label: 'Consumer Banking',
@@ -37,7 +39,7 @@ export default {
       handles: ['filter-tree-check']
     },
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     }
   },
   decorators: [

--- a/libs/web-components/filter-tree/stories/filter-tree.stories.ts
+++ b/libs/web-components/filter-tree/stories/filter-tree.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/filter-tree';
 import type { FilterTree } from '@finastra/filter-tree';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-filter-tree.json';
 
 const demoData = [
@@ -39,7 +39,7 @@ export default {
       handles: ['filter-tree-check']
     },
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     }
   },
   decorators: [

--- a/libs/web-components/get-started/stories/get-started.stories.ts
+++ b/libs/web-components/get-started/stories/get-started.stories.ts
@@ -1,6 +1,7 @@
 import '@finastra/button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 
 const README = require('../README.md');
 
@@ -8,7 +9,7 @@ export default {
   title: 'PATTERN/Get Started',
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/get-started/stories/get-started.stories.ts
+++ b/libs/web-components/get-started/stories/get-started.stories.ts
@@ -1,7 +1,7 @@
 import '@finastra/button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 
 const README = require('../README.md');
 
@@ -9,7 +9,7 @@ export default {
   title: 'PATTERN/Get Started',
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/global-nav/stories/global-nav.stories.ts
+++ b/libs/web-components/global-nav/stories/global-nav.stories.ts
@@ -7,7 +7,7 @@ import '@finastra/list';
 import '@finastra/sidenav';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 
 const README = require('../README.md');
 const demoApps = [
@@ -23,7 +23,7 @@ export default {
   title: 'PATTERN/Global Nav',
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/global-nav/stories/global-nav.stories.ts
+++ b/libs/web-components/global-nav/stories/global-nav.stories.ts
@@ -7,6 +7,7 @@ import '@finastra/list';
 import '@finastra/sidenav';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 
 const README = require('../README.md');
 const demoApps = [
@@ -22,7 +23,7 @@ export default {
   title: 'PATTERN/Global Nav',
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/global-search/README.md
+++ b/libs/web-components/global-search/README.md
@@ -66,7 +66,7 @@ import '@finastra/global-search';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/global-search/stories/global-search.stories.ts
+++ b/libs/web-components/global-search/stories/global-search.stories.ts
@@ -4,7 +4,7 @@ import { FDS_GLOBAL_SEARCH_INPUT_CHANGED, FDS_GLOBAL_SEARCH_ITEM_REMOVED, FDS_GL
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-global-search.json';
 
 export default {
@@ -24,7 +24,7 @@ export default {
       ]
     },
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design:{
       type: 'figma',

--- a/libs/web-components/global-search/stories/global-search.stories.ts
+++ b/libs/web-components/global-search/stories/global-search.stories.ts
@@ -4,6 +4,7 @@ import { FDS_GLOBAL_SEARCH_INPUT_CHANGED, FDS_GLOBAL_SEARCH_ITEM_REMOVED, FDS_GL
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-global-search.json';
 
 export default {
@@ -23,7 +24,7 @@ export default {
       ]
     },
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design:{
       type: 'figma',

--- a/libs/web-components/guided-tour/README.md
+++ b/libs/web-components/guided-tour/README.md
@@ -58,7 +58,7 @@ export interface Tour {
 - `stepInfo` property is a string template. Its default value is : `Step ${currentStep} of ${totalSteps}`
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/guided-tour/stories/guided-tour.stories.ts
+++ b/libs/web-components/guided-tour/stories/guided-tour.stories.ts
@@ -7,7 +7,7 @@ import '@finastra/icon-button';
 import '@finastra/user-profile';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-guided-tour.json';
 
 export default {
@@ -82,7 +82,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     cssprops
   },

--- a/libs/web-components/guided-tour/stories/guided-tour.stories.ts
+++ b/libs/web-components/guided-tour/stories/guided-tour.stories.ts
@@ -7,6 +7,7 @@ import '@finastra/icon-button';
 import '@finastra/user-profile';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-guided-tour.json';
 
 export default {
@@ -81,7 +82,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     cssprops
   },

--- a/libs/web-components/icon-bar/README.md
+++ b/libs/web-components/icon-bar/README.md
@@ -25,7 +25,7 @@ import '@finastra/icon-bar';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/icon-bar/stories/icon-bar.stories.ts
+++ b/libs/web-components/icon-bar/stories/icon-bar.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/icon-bar';
 import type { IconBar } from '@finastra/icon-bar';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import '../../../../themes/tippy.js/dist/theme.css';
 import { argTypes, cssprops } from './sb-generated/fds-icon-bar.json';
 
@@ -15,7 +16,7 @@ export default {
       handles: ['selected']
     },
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/icon-bar/stories/icon-bar.stories.ts
+++ b/libs/web-components/icon-bar/stories/icon-bar.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/icon-bar';
 import type { IconBar } from '@finastra/icon-bar';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import '../../../../themes/tippy.js/dist/theme.css';
 import { argTypes, cssprops } from './sb-generated/fds-icon-bar.json';
 
@@ -16,7 +16,7 @@ export default {
       handles: ['selected']
     },
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/icon-button/README.md
+++ b/libs/web-components/icon-button/README.md
@@ -21,7 +21,7 @@ import '@finastra/icon-button';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/icon-button/stories/icon-button.stories.ts
+++ b/libs/web-components/icon-button/stories/icon-button.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/icon-button';
 import type { IconButton } from '@finastra/icon-button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-icon-button.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/icon-button/stories/icon-button.stories.ts
+++ b/libs/web-components/icon-button/stories/icon-button.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/icon-button';
 import type { IconButton } from '@finastra/icon-button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-icon-button.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/icon/README.md
+++ b/libs/web-components/icon/README.md
@@ -23,7 +23,7 @@ import '@finastra/icon';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/icon/stories/icon.stories.ts
+++ b/libs/web-components/icon/stories/icon.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/icon';
 import type { Icon } from '@finastra/icon';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-icon.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/icon/stories/icon.stories.ts
+++ b/libs/web-components/icon/stories/icon.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/icon';
 import type { Icon } from '@finastra/icon';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-icon.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/launchpad/README.md
+++ b/libs/web-components/launchpad/README.md
@@ -31,7 +31,7 @@ import '@finastra/launchpad';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/launchpad/stories/launchpad.stories.ts
+++ b/libs/web-components/launchpad/stories/launchpad.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/launchpad';
 import { Launchpad } from '@finastra/launchpad';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes } from './sb-generated/fds-launchpad.json';
 
 
@@ -17,7 +18,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/launchpad/stories/launchpad.stories.ts
+++ b/libs/web-components/launchpad/stories/launchpad.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/launchpad';
 import { Launchpad } from '@finastra/launchpad';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes } from './sb-generated/fds-launchpad.json';
 
 
@@ -18,7 +18,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/linear-progress/README.md
+++ b/libs/web-components/linear-progress/README.md
@@ -23,7 +23,7 @@ import '@finastra/linear-progress';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/linear-progress/stories/linear-progress.stories.ts
+++ b/libs/web-components/linear-progress/stories/linear-progress.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/linear-progress';
 import type { LinearProgress } from '@finastra/linear-progress';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-linear-progress.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/linear-progress/stories/linear-progress.stories.ts
+++ b/libs/web-components/linear-progress/stories/linear-progress.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/linear-progress';
 import type { LinearProgress } from '@finastra/linear-progress';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-linear-progress.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/list/README.md
+++ b/libs/web-components/list/README.md
@@ -32,7 +32,7 @@ import '@finastra/list';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/list/stories/list.stories.ts
+++ b/libs/web-components/list/stories/list.stories.ts
@@ -4,7 +4,7 @@ import type { List } from '@finastra/list';
 import '@material/mwc-icon';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-list.json';
 
 export default {
@@ -13,7 +13,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     }
   },
   decorators: [

--- a/libs/web-components/list/stories/list.stories.ts
+++ b/libs/web-components/list/stories/list.stories.ts
@@ -4,6 +4,7 @@ import type { List } from '@finastra/list';
 import '@material/mwc-icon';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-list.json';
 
 export default {
@@ -12,7 +13,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     }
   },
   decorators: [

--- a/libs/web-components/logo/README.md
+++ b/libs/web-components/logo/README.md
@@ -41,7 +41,7 @@ url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdm
 <br/>
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Attributes
 

--- a/libs/web-components/logo/stories/logo.stories.ts
+++ b/libs/web-components/logo/stories/logo.stories.ts
@@ -2,7 +2,7 @@ const README = require('../README.md');
 import '@finastra/logo';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-logo.json';
 
 export default {
@@ -14,7 +14,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/logo/stories/logo.stories.ts
+++ b/libs/web-components/logo/stories/logo.stories.ts
@@ -2,6 +2,7 @@ const README = require('../README.md');
 import '@finastra/logo';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-logo.json';
 
 export default {
@@ -13,7 +14,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/menu-trigger/README.md
+++ b/libs/web-components/menu-trigger/README.md
@@ -22,7 +22,7 @@ import '@finastra/menu-trigger';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/menu-trigger/stories/menu-trigger.stories.ts
+++ b/libs/web-components/menu-trigger/stories/menu-trigger.stories.ts
@@ -2,7 +2,7 @@ import '@finastra/menu-trigger';
 import { MenuTrigger } from '@finastra/menu-trigger';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes } from './sb-generated/fds-menu-trigger.json';
 
 
@@ -17,7 +17,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/menu-trigger/stories/menu-trigger.stories.ts
+++ b/libs/web-components/menu-trigger/stories/menu-trigger.stories.ts
@@ -2,6 +2,7 @@ import '@finastra/menu-trigger';
 import { MenuTrigger } from '@finastra/menu-trigger';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes } from './sb-generated/fds-menu-trigger.json';
 
 
@@ -16,7 +17,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/menu/README.md
+++ b/libs/web-components/menu/README.md
@@ -50,7 +50,7 @@ import '@finastra/list';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/menu/stories/menu.stories.ts
+++ b/libs/web-components/menu/stories/menu.stories.ts
@@ -6,7 +6,7 @@ import type { Menu } from '@finastra/menu';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-menu.json';
 
 export default {
@@ -18,7 +18,7 @@ export default {
       handles: ['opened', 'closing', 'closed', 'action', 'selected']
     },
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     cssprops
   },

--- a/libs/web-components/menu/stories/menu.stories.ts
+++ b/libs/web-components/menu/stories/menu.stories.ts
@@ -6,6 +6,7 @@ import type { Menu } from '@finastra/menu';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-menu.json';
 
 export default {
@@ -17,7 +18,7 @@ export default {
       handles: ['opened', 'closing', 'closed', 'action', 'selected']
     },
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     cssprops
   },

--- a/libs/web-components/radio/README.md
+++ b/libs/web-components/radio/README.md
@@ -22,7 +22,7 @@ import '@finastra/radio';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/radio/stories/radio.stories.ts
+++ b/libs/web-components/radio/stories/radio.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/radio';
 import type { Radio } from '@finastra/radio';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-radio.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/radio/stories/radio.stories.ts
+++ b/libs/web-components/radio/stories/radio.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/radio';
 import type { Radio } from '@finastra/radio';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-radio.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/search-input/README.md
+++ b/libs/web-components/search-input/README.md
@@ -23,7 +23,7 @@ import '@finastra/search-input';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/search-input/stories/search-input.stories.ts
+++ b/libs/web-components/search-input/stories/search-input.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/search-input';
 import type { SearchInput } from '@finastra/search-input';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-search-input.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/search-input/stories/search-input.stories.ts
+++ b/libs/web-components/search-input/stories/search-input.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/search-input';
 import type { SearchInput } from '@finastra/search-input';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-search-input.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/select/README.md
+++ b/libs/web-components/select/README.md
@@ -26,7 +26,7 @@ import '@finastra/select';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/select/stories/select.stories.ts
+++ b/libs/web-components/select/stories/select.stories.ts
@@ -4,6 +4,7 @@ import '@finastra/select';
 import type { Select } from '@finastra/select';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-select.json';
 
 export default {
@@ -12,7 +13,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/select/stories/select.stories.ts
+++ b/libs/web-components/select/stories/select.stories.ts
@@ -4,7 +4,7 @@ import '@finastra/select';
 import type { Select } from '@finastra/select';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-select.json';
 
 export default {
@@ -13,7 +13,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/sidenav/README.md
+++ b/libs/web-components/sidenav/README.md
@@ -32,7 +32,7 @@ import '@finastra/sidenav';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/sidenav/stories/sidenav.stories.ts
+++ b/libs/web-components/sidenav/stories/sidenav.stories.ts
@@ -6,7 +6,7 @@ import '@finastra/sidenav';
 import { DRAWER_TYPES, Sidenav } from '@finastra/sidenav';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes } from './sb-generated/fds-sidenav.json';
 
 export default {
@@ -17,7 +17,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/sidenav/stories/sidenav.stories.ts
+++ b/libs/web-components/sidenav/stories/sidenav.stories.ts
@@ -6,6 +6,7 @@ import '@finastra/sidenav';
 import { DRAWER_TYPES, Sidenav } from '@finastra/sidenav';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes } from './sb-generated/fds-sidenav.json';
 
 export default {
@@ -16,7 +17,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/skeleton/README.md
+++ b/libs/web-components/skeleton/README.md
@@ -20,7 +20,7 @@ import '@finastra/skeleton';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/skeleton/stories/skeleton.stories.ts
+++ b/libs/web-components/skeleton/stories/skeleton.stories.ts
@@ -4,14 +4,16 @@ import type { Skeleton } from '@finastra/skeleton';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-skeleton.json';
+
 export default {
   title: 'DATA DISPLAY/Skeleton',
   component: 'fds-skeleton',
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     cssprops
   },

--- a/libs/web-components/skeleton/stories/skeleton.stories.ts
+++ b/libs/web-components/skeleton/stories/skeleton.stories.ts
@@ -4,7 +4,7 @@ import type { Skeleton } from '@finastra/skeleton';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-skeleton.json';
 
 export default {
@@ -13,7 +13,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     cssprops
   },

--- a/libs/web-components/slider/README.md
+++ b/libs/web-components/slider/README.md
@@ -24,7 +24,7 @@ import '@finastra/slider';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/slider/stories/slider.stories.ts
+++ b/libs/web-components/slider/stories/slider.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/slider';
 import type { Slider } from '@finastra/slider';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-slider.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/slider/stories/slider.stories.ts
+++ b/libs/web-components/slider/stories/slider.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/slider';
 import type { Slider } from '@finastra/slider';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-slider.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/status-message/stories/status-messages.stories.ts
+++ b/libs/web-components/status-message/stories/status-messages.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/icon';
 import '@finastra/textfield';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 
 
 const README = require('../README.md');
@@ -17,7 +18,7 @@ export default {
   title: 'PATTERN/Status Message',
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/status-message/stories/status-messages.stories.ts
+++ b/libs/web-components/status-message/stories/status-messages.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/icon';
 import '@finastra/textfield';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 
 
 const README = require('../README.md');
@@ -18,7 +18,7 @@ export default {
   title: 'PATTERN/Status Message',
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/stepper/README.md
+++ b/libs/web-components/stepper/README.md
@@ -47,7 +47,7 @@ this.steps = [
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Attributes
 

--- a/libs/web-components/stepper/stories/horizontal-stepper.stories.ts
+++ b/libs/web-components/stepper/stories/horizontal-stepper.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/stepper';
 import type { HorizontalStepper } from '@finastra/stepper';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { EVENTS } from '../src/constants';
 import { argTypes, cssprops } from './sb-generated/fds-horizontal-stepper.json';
 
@@ -50,7 +51,7 @@ export default {
       handles: [EVENTS.STEPCLICK]
     },
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/stepper/stories/horizontal-stepper.stories.ts
+++ b/libs/web-components/stepper/stories/horizontal-stepper.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/stepper';
 import type { HorizontalStepper } from '@finastra/stepper';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { EVENTS } from '../src/constants';
 import { argTypes, cssprops } from './sb-generated/fds-horizontal-stepper.json';
 
@@ -51,7 +51,7 @@ export default {
       handles: [EVENTS.STEPCLICK]
     },
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/stepper/stories/vertical-stepper.stories.ts
+++ b/libs/web-components/stepper/stories/vertical-stepper.stories.ts
@@ -3,8 +3,10 @@ import '@finastra/stepper';
 import type { VerticalStepper } from '@finastra/stepper';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { EVENTS } from '../src/constants';
 import { argTypes, cssprops } from './sb-generated/fds-vertical-stepper.json';
+
 const demoData = [
   {
     label: 'Step Success',
@@ -71,7 +73,7 @@ export default {
       handles: [EVENTS.STEPCLICK]
     },
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/stepper/stories/vertical-stepper.stories.ts
+++ b/libs/web-components/stepper/stories/vertical-stepper.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/stepper';
 import type { VerticalStepper } from '@finastra/stepper';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { EVENTS } from '../src/constants';
 import { argTypes, cssprops } from './sb-generated/fds-vertical-stepper.json';
 
@@ -73,7 +73,7 @@ export default {
       handles: [EVENTS.STEPCLICK]
     },
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/switch/README.md
+++ b/libs/web-components/switch/README.md
@@ -24,7 +24,7 @@ import '@finastra/switch';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/switch/stories/switch.stories.ts
+++ b/libs/web-components/switch/stories/switch.stories.ts
@@ -2,7 +2,7 @@ const README = require('../README.md');
 import '@finastra/switch';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-switch.json';
 
 export default {
@@ -15,7 +15,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/switch/stories/switch.stories.ts
+++ b/libs/web-components/switch/stories/switch.stories.ts
@@ -2,6 +2,7 @@ const README = require('../README.md');
 import '@finastra/switch';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-switch.json';
 
 export default {
@@ -14,7 +15,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/tabs/README.md
+++ b/libs/web-components/tabs/README.md
@@ -22,7 +22,7 @@ import '@finastra/tabs';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/tabs/stories/tabs.stories.ts
+++ b/libs/web-components/tabs/stories/tabs.stories.ts
@@ -2,7 +2,7 @@ const README = require('../README.md');
 import '@finastra/tabs';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-tab-group.json';
 
 export default {
@@ -11,7 +11,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/tabs/stories/tabs.stories.ts
+++ b/libs/web-components/tabs/stories/tabs.stories.ts
@@ -2,6 +2,7 @@ const README = require('../README.md');
 import '@finastra/tabs';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-tab-group.json';
 
 export default {
@@ -10,7 +11,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/textarea/README.md
+++ b/libs/web-components/textarea/README.md
@@ -23,7 +23,7 @@ import '@finastra/textarea';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/textarea/stories/textarea.stories.ts
+++ b/libs/web-components/textarea/stories/textarea.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/textarea';
 import type { Textarea } from '@finastra/textarea';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-textarea.json';
 
 export default {
@@ -16,7 +16,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/textarea/stories/textarea.stories.ts
+++ b/libs/web-components/textarea/stories/textarea.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/textarea';
 import type { Textarea } from '@finastra/textarea';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-textarea.json';
 
 export default {
@@ -15,7 +16,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/textfield/README.md
+++ b/libs/web-components/textfield/README.md
@@ -35,7 +35,7 @@ The **TextField** support date `type="date"`, time `type="time"` and date&time `
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/textfield/stories/textfield.stories.ts
+++ b/libs/web-components/textfield/stories/textfield.stories.ts
@@ -4,6 +4,7 @@ import '@finastra/textfield';
 import type { TextField } from '@finastra/textfield';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-textfield.json';
 
 export default {
@@ -12,7 +13,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/textfield/stories/textfield.stories.ts
+++ b/libs/web-components/textfield/stories/textfield.stories.ts
@@ -4,7 +4,7 @@ import '@finastra/textfield';
 import type { TextField } from '@finastra/textfield';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-textfield.json';
 
 export default {
@@ -13,7 +13,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/tooltip/stories/tooltip.stories.ts
+++ b/libs/web-components/tooltip/stories/tooltip.stories.ts
@@ -2,6 +2,7 @@ import '@finastra/button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import 'tippy.js/dist/tippy.css';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import '../../../../themes/tippy.js/dist/theme.css';
 
 const README = require('../README.md');
@@ -10,7 +11,7 @@ export default {
   title: 'POPOVER/Tooltip',
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     }
   },
   args: {

--- a/libs/web-components/tooltip/stories/tooltip.stories.ts
+++ b/libs/web-components/tooltip/stories/tooltip.stories.ts
@@ -2,7 +2,7 @@ import '@finastra/button';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import 'tippy.js/dist/tippy.css';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import '../../../../themes/tippy.js/dist/theme.css';
 
 const README = require('../README.md');
@@ -11,7 +11,7 @@ export default {
   title: 'POPOVER/Tooltip',
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     }
   },
   args: {

--- a/libs/web-components/user-profile/README.md
+++ b/libs/web-components/user-profile/README.md
@@ -29,7 +29,7 @@ import '@finastra/user-profile';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/user-profile/stories/user-profile.stories.ts
+++ b/libs/web-components/user-profile/stories/user-profile.stories.ts
@@ -4,7 +4,7 @@ import '@finastra/user-profile';
 import type { UserProfile } from '@finastra/user-profile';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-user-profile.json';
 
 export default {
@@ -17,7 +17,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/user-profile/stories/user-profile.stories.ts
+++ b/libs/web-components/user-profile/stories/user-profile.stories.ts
@@ -4,6 +4,7 @@ import '@finastra/user-profile';
 import type { UserProfile } from '@finastra/user-profile';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-user-profile.json';
 
 export default {
@@ -16,7 +17,7 @@ export default {
   },
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/wizard/README.md
+++ b/libs/web-components/wizard/README.md
@@ -52,7 +52,7 @@ import '@finastra/button';
 ```
 
 
-### Documentation
+### API
 <!-- DOC -->
 #### Properties
 

--- a/libs/web-components/wizard/stories/wizard.stories.ts
+++ b/libs/web-components/wizard/stories/wizard.stories.ts
@@ -3,7 +3,7 @@ import '@finastra/wizard';
 import { POSITION, Wizard } from '@finastra/wizard';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-wizard.json';
 
 export default {
@@ -12,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
     design: {
       type: 'figma',

--- a/libs/web-components/wizard/stories/wizard.stories.ts
+++ b/libs/web-components/wizard/stories/wizard.stories.ts
@@ -3,6 +3,7 @@ import '@finastra/wizard';
 import { POSITION, Wizard } from '@finastra/wizard';
 import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 import { argTypes, cssprops } from './sb-generated/fds-wizard.json';
 
 export default {
@@ -11,7 +12,7 @@ export default {
   argTypes,
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
     design: {
       type: 'figma',

--- a/scripts/markdown-sanitizers.js
+++ b/scripts/markdown-sanitizers.js
@@ -1,16 +1,32 @@
+const { matches } = require("lodash-es");
+
 function wcaApiDocRemover(markdown) {
   const regex = /(<!-- DOC.* -->)(.*)(<!-- \/DOC.* -->)/gms;
   return markdown.replace(regex, '');
 };
 
-function storybookButton(markdown) {
+function storybookButton(markdown, replace) {
   const regex = /\[\!\[Storybook\](.*)/gm;
-  return markdown.replace(regex, '');
+  return markdown.replace(regex, replace);
 };
 
+function githubReadme(link) {
+  const GITHUB_BADGE = 'https://img.shields.io/badge/GitHub-README-000?style=for-the-badge&logo=github&logoColor=white';
+  return `[![${GITHUB_BADGE}](${GITHUB_BADGE})](${link})`;
+}
+
+function getLinkToReadme(componentPath) {
+  return `https://github.com/Finastra/finastra-design-system/blob/master/libs/web-components/${componentPath}/README.md`;
+}
+
+function getPathToComponent(markdown) {
+  let regex = /https:\/\/www\.npmjs\.com\/package\/@finastra\/(.*)\)/gm;
+  const matches = regex.exec(markdown);
+  return matches.length > 0 ? matches[1] : '';
+}
+
 function allSanitizers(markdown) {
-  return markdown;
-  return storybookButton(wcaApiDocRemover(markdown));
+  return storybookButton(wcaApiDocRemover(markdown), githubReadme(getLinkToReadme(getPathToComponent(markdown))));
 }
 
 module.exports = {

--- a/scripts/markdown-sanitizers.js
+++ b/scripts/markdown-sanitizers.js
@@ -1,4 +1,13 @@
-module.exports.wcaDocRemover = function (markdown) {
+module.exports.wcaApiDocRemover = function (markdown) {
   const regex = /(<!-- DOC.* -->)(.*)(<!-- \/DOC.* -->)/gms;
   return markdown.replace(regex, '');
 };
+
+module.exports.storybookButton = function (markdown) {
+  const regex = /\[\!\[Storybook\](.*)/gm;
+  return markdown.replace(regex, '');
+};
+
+module.exports.allSanitizers = function(markdown) {
+  return this.storybookButton(this.wcaApiDocRemover(markdown));
+}

--- a/scripts/markdown-sanitizers.js
+++ b/scripts/markdown-sanitizers.js
@@ -1,13 +1,19 @@
-module.exports.wcaApiDocRemover = function (markdown) {
+function wcaApiDocRemover(markdown) {
   const regex = /(<!-- DOC.* -->)(.*)(<!-- \/DOC.* -->)/gms;
   return markdown.replace(regex, '');
 };
 
-module.exports.storybookButton = function (markdown) {
+function storybookButton(markdown) {
   const regex = /\[\!\[Storybook\](.*)/gm;
   return markdown.replace(regex, '');
 };
 
-module.exports.allSanitizers = function(markdown) {
-  return this.storybookButton(this.wcaApiDocRemover(markdown));
+function allSanitizers(markdown) {
+  return storybookButton(wcaApiDocRemover(markdown));
+}
+
+module.exports = {
+  wcaApiDocRemover,
+  storybookButton,
+  allSanitizers
 }

--- a/scripts/markdown-sanitizers.js
+++ b/scripts/markdown-sanitizers.js
@@ -1,0 +1,4 @@
+module.exports.wcaDocRemover = function (markdown) {
+  const regex = /(<!-- DOC.* -->)(.*)(<!-- \/DOC.* -->)/gms;
+  return markdown.replace(regex, '');
+};

--- a/scripts/markdown-sanitizers.js
+++ b/scripts/markdown-sanitizers.js
@@ -9,6 +9,7 @@ function storybookButton(markdown) {
 };
 
 function allSanitizers(markdown) {
+  return markdown;
   return storybookButton(wcaApiDocRemover(markdown));
 }
 

--- a/tools/generators/web-component/files/README.md
+++ b/tools/generators/web-component/files/README.md
@@ -19,6 +19,6 @@ import '@finastra/<%= fileName %>';
 <fds-<%= fileName %>></fds-<%= fileName %>>
 ```
 
-### Documentation
+### API
 <!-- DOC -->
 <!-- /DOC -->

--- a/tools/generators/web-component/files/stories/__fileName__.stories.ts.template
+++ b/tools/generators/web-component/files/stories/__fileName__.stories.ts.template
@@ -4,7 +4,7 @@ import { html } from 'lit-html';
 import '@finastra/<%= fileName %>';
 import type {<%=className%>} from '@finastra/<%= fileName %>';
 import { argTypes, cssprops } from './sb-generated/fds-<%= fileName %>.json';
-import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
 
 export default {
   title: 'Components/<%= className %>',
@@ -15,7 +15,7 @@ export default {
   }, 
   parameters: {
     docs: {
-      description: { component: wcaDocRemover(README) }
+      description: { component: allSanitizers(README) }
     },
   },
   decorators: [

--- a/tools/generators/web-component/files/stories/__fileName__.stories.ts.template
+++ b/tools/generators/web-component/files/stories/__fileName__.stories.ts.template
@@ -4,7 +4,7 @@ import { html } from 'lit-html';
 import '@finastra/<%= fileName %>';
 import type {<%=className%>} from '@finastra/<%= fileName %>';
 import { argTypes, cssprops } from './sb-generated/fds-<%= fileName %>.json';
-
+import { wcaDocRemover } from '../../../../scripts/markdown-sanitizers';
 
 export default {
   title: 'Components/<%= className %>',
@@ -15,7 +15,7 @@ export default {
   }, 
   parameters: {
     docs: {
-      description: { component: README }
+      description: { component: wcaDocRemover(README) }
     },
   },
   decorators: [


### PR DESCRIPTION
Changes in storybook "Docs" tab:
- [x] Remove already present API doc
- [x] Remove (self) Storybook button
- [x] Add Github readme button