### PR TITLE
fix(action): replace deprecated set-output

### DIFF
--- a/.github/workflows/release-wc.yml
+++ b/.github/workflows/release-wc.yml
@@ -41,9 +41,9 @@ jobs:
           http_status_code=$(curl -LI $GET_API_URL -o /dev/null -w '%{http_code}\n' -s \
             -H "Authorization: token ${GITHUB_TOKEN}")
           if [ "$http_status_code" -ne "404" ] ; then
-            echo "::set-output name=exists_tag::true"
+            echo "exists_tag=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=exists_tag::false"
+            echo "exists_tag=false" >> $GITHUB_OUTPUT
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Following this GH suggestion
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/