### PR TITLE
fix(angular-theme): :pencil2: Fix typo for crimson palette

### DIFF
--- a/themes/angular-theme/lib/core/theming/_palette.scss
+++ b/themes/angular-theme/lib/core/theming/_palette.scss
@@ -112,7 +112,7 @@ $uxg-fuchsia: (
 $uxg-crimson: (
   25: #f8bdcf,
   50: #f17fa2,
-  75: rgba(var(--color-error-ligther), 1),
+  75: rgba(var(--color-error-lighter), 1),
   100: rgba(var(--color-error), 1),
   100-dark: rgba(var(--color-error-darker), 1),
   contrast: (


### PR DESCRIPTION
Fixes #991