### PR TITLE
feature(wc): fds formfield

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -760,6 +760,18 @@
       },
       "tags": []
     },
+    "formfield": {
+      "root": "libs/web-components/formfield",
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": ["libs/web-components/formfield/src/**/*.ts"]
+          }
+        }
+      },
+      "tags": ["web-components"]
+    },
     "global-nav": {
       "$schema": "../../../node_modules/nx/schemas/project-schema.json",
       "projectType": "library",

--- a/libs/web-components/checkbox/stories/checkbox.stories.ts
+++ b/libs/web-components/checkbox/stories/checkbox.stories.ts
@@ -30,8 +30,21 @@ const Template: Story = ({ checked, indeterminate, disabled }) => {
   return html`<fds-checkbox ?checked=${checked} ?indeterminate=${indeterminate} ?disabled=${disabled}></fds-checkbox>`;
 };
 
+const WithLabelTemplate: Story = ({ checked }) => {
+  return html`
+    <fds-formfield label="Accept terms and conditions">
+      <fds-checkbox ?checked=${checked} ></fds-checkbox>
+    </fds-formfield>`;
+};
+
+
 export const Default: Story = Template.bind({});
 Default.args = {
+  checked: true
+};
+
+export const WithLabel: Story = WithLabelTemplate.bind({});
+WithLabel.args = {
   checked: true
 };
 

--- a/libs/web-components/filter-tree/package.json
+++ b/libs/web-components/filter-tree/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@finastra/icon-button": "1.2.17",
-    "@material/mwc-formfield": "0.27.0",
+    "@finastra/formfield": "1.2.17",
     "lit": "^2.0.0",
     "tslib": "^2.0.1"
   },

--- a/libs/web-components/filter-tree/src/tree-item/tree-item.ts
+++ b/libs/web-components/filter-tree/src/tree-item/tree-item.ts
@@ -1,6 +1,6 @@
 import "@finastra/checkbox";
 import "@finastra/icon-button";
-import "@material/mwc-formfield";
+import "@finastra/formfield";
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { styles } from './tree-item.css';
@@ -29,9 +29,9 @@ export class TreeItem extends LitElement {
   render() {
     return html`
     <div class="filter-item">
-    <mwc-formfield label=${this.label}>
+    <fds-formfield label=${this.label}>
       <fds-checkbox @change=${this.onChange} ?checked=${this.selected} ?indeterminate=${this.indeterminate}></fds-checkbox>
-    </mwc-formfield>
+    </fds-formfield>
     ${this.hideExpandIcon ? 
       html`<fds-icon-button icon=${this.expandIcon} @click="${this.toggleList}"></fds-icon-button>
       </div>` : ''}

--- a/libs/web-components/formfield/.eslintrc.json
+++ b/libs/web-components/formfield/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "parserOptions": {
+        "project": ["libs/web-components/formfield/tsconfig.*?.json"]
+      },
+      "rules": {}
+    },
+    {
+      "files": ["*.html"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/web-components/formfield/.npmignore
+++ b/libs/web-components/formfield/.npmignore
@@ -1,0 +1,8 @@
+.tsbuildinfo
+tsconfig.json
+.eslintignore
+*.tgz
+images/*
+test/*
+*.ts
+!*.d.ts

--- a/libs/web-components/formfield/README.md
+++ b/libs/web-components/formfield/README.md
@@ -20,8 +20,11 @@ npm i @finastra/formfield
 
 ```ts
 import '@finastra/formfield';
+import '@finastra/checkbox';
 ...
-<fds-formfield></fds-formfield>
+<fds-formfield label="Accept terms and conditions">
+    <fds-checkbox checked></fds-checkbox>
+</fds-formfield>
 ```
 
 ### API

--- a/libs/web-components/formfield/README.md
+++ b/libs/web-components/formfield/README.md
@@ -1,0 +1,30 @@
+# Formfield
+
+[![See it on NPM!](https://img.shields.io/npm/v/@finastra/formfield?style=for-the-badge)](https://www.npmjs.com/package/@finastra/formfield)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@finastra/formfield?style=for-the-badge)](https://bundlephobia.com/result?p=@finastra/formfield')
+[![Storybook](https://shields.io/badge/-Play%20with%20this%20web%20component-2a0481?logo=storybook&style=for-the-badge)](https://finastra.github.io/finastra-design-system/?path=/story/components-formfield--default)
+
+## Usage
+
+A form field is a text caption for MWC input elements including [fds-checkbox](https://finastra.github.io/finastra-design-system/?path=/docs/forms-checkbox--default), [fds-radio](https://finastra.github.io/finastra-design-system/?path=/docs/forms-radio--default), and [fds-switch](https://finastra.github.io/finastra-design-system/?path=/docs/forms-switch--default).
+
+It is equivalent to the native <label> element in that it forwards user interaction events to the input element. For example, tapping on the label causes the associated input element to toggle and focus.
+
+`fds-formfield` extends [Material web's mwc-formfield-base](https://github.com/material-components/material-web/tree/mwc/components/formfield).
+
+### Import
+
+```
+npm i @finastra/formfield
+```
+
+```ts
+import '@finastra/formfield';
+...
+<fds-formfield></fds-formfield>
+```
+
+### API
+
+<!-- DOC -->
+<!-- /DOC -->

--- a/libs/web-components/formfield/README.md
+++ b/libs/web-components/formfield/README.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-A form field is a text caption for MWC input elements including [fds-checkbox](https://finastra.github.io/finastra-design-system/?path=/docs/forms-checkbox--default), [fds-radio](https://finastra.github.io/finastra-design-system/?path=/docs/forms-radio--default), and [fds-switch](https://finastra.github.io/finastra-design-system/?path=/docs/forms-switch--default).
+A form field is a text caption for FDS input elements including [fds-checkbox](https://finastra.github.io/finastra-design-system/?path=/docs/forms-checkbox--default), [fds-radio](https://finastra.github.io/finastra-design-system/?path=/docs/forms-radio--default), and [fds-switch](https://finastra.github.io/finastra-design-system/?path=/docs/forms-switch--default).
 
 It is equivalent to the native <label> element in that it forwards user interaction events to the input element. For example, tapping on the label causes the associated input element to toggle and focus.
 

--- a/libs/web-components/formfield/demo/index.html
+++ b/libs/web-components/formfield/demo/index.html
@@ -1,6 +1,6 @@
 <script type="module" src="node_modules/@finastra/formfield/dist/src/formfield.js"></script>
 <script type="module" src="node_modules/@finastra/checkbox/dist/src/checkbox.js"></script>
 
-<fds-formfield alignEnd label="Tomato" spaceBetween>
+<fds-formfield label="Accept terms and conditions">
     <fds-checkbox checked></fds-checkbox>
 </fds-formfield>

--- a/libs/web-components/formfield/demo/index.html
+++ b/libs/web-components/formfield/demo/index.html
@@ -1,0 +1,6 @@
+<script type="module" src="node_modules/@finastra/formfield/dist/src/formfield.js"></script>
+<script type="module" src="node_modules/@finastra/checkbox/dist/src/checkbox.js"></script>
+
+<fds-formfield alignEnd label="Tomato" spaceBetween>
+    <fds-checkbox checked></fds-checkbox>
+</fds-formfield>

--- a/libs/web-components/formfield/package.json
+++ b/libs/web-components/formfield/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@finastra/formfield",
+  "displayName": "Formfield",
+  "version": "1.2.17",
+  "description": "Formfield Web Component",
+  "keywords": [
+    "Finastra Design System",
+    "Web Components",
+    "Formfield"
+  ],
+  "license": "MIT",
+  "main": "dist/src/formfield.js",
+  "module": "dist/src/formfield.js",
+  "scripts": {
+    "build:style": "node ../../../scripts/sass-to-lit-css/index.js src/styles.scss"
+  },
+  "dependencies": {
+    "lit": "^2.0.0",
+    "tslib": "^2.0.1",
+    "@material/mwc-formfield": "0.27.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/libs/web-components/formfield/src/formfield.ts
+++ b/libs/web-components/formfield/src/formfield.ts
@@ -1,0 +1,22 @@
+import { FormfieldBase } from '@material/mwc-formfield/mwc-formfield-base';
+import { customElement } from 'lit/decorators.js';
+import { styles } from './styles.css';
+
+/**
+ * @cssprop [--fds-label-font=#694ED6] - Switch color
+ * @attr [label=''] - The text to display for the label and sets a11y label on input. (visually overriden by slotted label).
+ * @attr [alignEnd=false] - Align the component at the end of the label..
+ * @attr [spaceBetween=false] - Add space between the component and the label as the formfield grows.
+ * @attr [nowrap=false] - Prevents the label from wrapping and overflow text is ellipsed.
+ */
+
+@customElement('fds-formfield')
+export class Formfield extends FormfieldBase {
+  static styles = styles;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'fds-formfield': Formfield;
+  }
+}

--- a/libs/web-components/formfield/src/styles.scss
+++ b/libs/web-components/formfield/src/styles.scss
@@ -1,0 +1,7 @@
+@use '@material/mwc-formfield/mwc-formfield';
+@use '@finastra/fds-theme' as fds;
+
+:host {
+  display: block;
+  @include fds.mdc(theme-text-primary-on-background, on-background);
+}

--- a/libs/web-components/formfield/stories/formfield.stories.ts
+++ b/libs/web-components/formfield/stories/formfield.stories.ts
@@ -37,7 +37,6 @@ const Switch: Story<Formfield> = ({label, alignEnd, spaceBetween, nowrap }) => {
 </fds-formfield>`;
 };
 
-
 export const CheckboxTemplate: Story<Formfield> = Checkbox.bind({});
 CheckboxTemplate.args = {
   label: "Accept terms and conditions"
@@ -57,3 +56,5 @@ export const SwitchTemplate: Story<Formfield> = Switch.bind({});
 SwitchTemplate.args = {
   label: "On"
 };
+
+

--- a/libs/web-components/formfield/stories/formfield.stories.ts
+++ b/libs/web-components/formfield/stories/formfield.stories.ts
@@ -1,0 +1,59 @@
+const README = require('../README.md');
+import '@finastra/formfield';
+import type { Formfield } from '@finastra/formfield';
+import { Meta, Story } from '@storybook/web-components';
+import { html } from 'lit-html';
+import { allSanitizers } from '../../../../scripts/markdown-sanitizers';
+import { argTypes, cssprops } from './sb-generated/fds-formfield.json';
+
+export default {
+  title: 'FORMS/Formfield',
+  component: 'fds-formfield',
+  argTypes,
+  parameters: {
+    docs: {
+      description: { component: allSanitizers(README) }
+    }
+  },
+  cssprops
+} as Meta;
+
+const Checkbox: Story<Formfield> = ({label, alignEnd, spaceBetween, nowrap }) => {
+  return html`<fds-formfield label=${label} ?alignEnd=${alignEnd} ?spaceBetween=${spaceBetween} ?nowrap=${nowrap}>
+      <fds-checkbox></fds-checkbox>
+</fds-formfield>`;
+};
+
+const Radio: Story<Formfield> = ({label, alignEnd, spaceBetween, nowrap }) => {
+  return html`<fds-formfield label=${label} ?alignEnd=${alignEnd} ?spaceBetween=${spaceBetween} ?nowrap=${nowrap}>
+      <fds-radio checked></fds-radio>
+</fds-formfield>`;
+};
+
+
+const Switch: Story<Formfield> = ({label, alignEnd, spaceBetween, nowrap }) => {
+  return html`<fds-formfield label=${label} ?alignEnd=${alignEnd} ?spaceBetween=${spaceBetween} ?nowrap=${nowrap}>
+      <fds-switch selected></fds-switch>
+</fds-formfield>`;
+};
+
+
+export const CheckboxTemplate: Story<Formfield> = Checkbox.bind({});
+CheckboxTemplate.args = {
+  label: "Accept terms and conditions"
+};
+
+export const AlignEnd: Story = CheckboxTemplate.bind({});
+AlignEnd.args = {
+  label: "Accept terms and conditions",
+  alignEnd: true
+};
+
+export const RadioTemplate: Story<Formfield> = Radio.bind({});
+RadioTemplate.args = {
+  label: "Option"
+};
+export const SwitchTemplate: Story<Formfield> = Switch.bind({});
+SwitchTemplate.args = {
+  label: "On"
+};

--- a/libs/web-components/formfield/test/formfield.test.ts
+++ b/libs/web-components/formfield/test/formfield.test.ts
@@ -1,0 +1,12 @@
+import { html, fixture, expect, elementUpdated } from '@open-wc/testing';
+import { Formfield } from '../src/formfield.js';
+import '../src/formfield.js';
+
+describe('Formfield', () => {
+  it('loads accessibly', async () => {
+    const el: Formfield = await fixture(html`<fds-formfield></fds-formfield>`);
+
+    await elementUpdated(el);
+    await expect(el).to.be.accessible();
+  });
+});

--- a/libs/web-components/formfield/tsconfig.json
+++ b/libs/web-components/formfield/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "./",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/libs/web-components/radio/stories/radio.stories.ts
+++ b/libs/web-components/radio/stories/radio.stories.ts
@@ -26,6 +26,13 @@ const Template: Story<Radio> = ({ checked, disabled, global, name, reducedTouchT
   return html`<fds-radio ?checked=${checked} ?disabled=${disabled} ?global=${global} ?name=${name} ?reducedTouchTarget=${reducedTouchTarget} ?value=${value}></fds-radio>`;
 };
 
+const WithLabelTemplate: Story = ({ checked }) => {
+  return html`
+    <fds-formfield label="Option">
+      <fds-radio checked=${checked}></fds-radio>
+    </fds-formfield>`;
+};
+
 export const Default: Story<Radio> = Template.bind({});
 Default.args = {
   checked: false
@@ -35,4 +42,9 @@ export const Disabled: Story<Radio> = Template.bind({});
 Disabled.args = {
   checked: true,
   disabled: true
+};
+
+export const WithLabel: Story = WithLabelTemplate.bind({});
+WithLabel.args = {
+  checked: true
 };

--- a/libs/web-components/switch/src/styles.scss
+++ b/libs/web-components/switch/src/styles.scss
@@ -35,8 +35,10 @@ $track-color-opacity: 0.54;
 
   /* disabled state */
   @include fds.mdc(switch-disabled-unselected-handle-color, surface);
-   @include fds.mdc(switch-disabled-unselected-track-color, on-surface-medium);
-   --mdc-switch-disabled-track-opacity: 0.3;
+  @include fds.mdc(switch-disabled-unselected-track-color, on-surface-medium);
+
+  --mdc-typography-body2-line-height: 0px;
+  --mdc-switch-disabled-track-opacity: 0.3;
 }
 
 .mdc-switch__handle::before,
@@ -54,3 +56,4 @@ $track-color-opacity: 0.54;
 .mdc-switch.mdc-switch--selected:disabled .mdc-switch__icon {
   fill: none;
 }
+

--- a/libs/web-components/switch/stories/switch.stories.ts
+++ b/libs/web-components/switch/stories/switch.stories.ts
@@ -29,6 +29,12 @@ const Template: Story = ({ selected, disabled }) => {
   return html`<fds-switch ?selected=${selected} ?disabled=${disabled}></fds-switch>`;
 };
 
+const WithLabelTemplate: Story = ({ selected }) => {
+  return html`
+    <fds-formfield label="On">
+      <fds-switch selected=${selected}></fds-switch>
+    </fds-formfield>`;
+};
 export const Default: Story = Template.bind({});
 
 export const Selected: Story = Template.bind({});
@@ -39,4 +45,9 @@ Selected.args = {
 export const Disabled: Story = Template.bind({});
 Disabled.args = {
   disabled: true
+};
+
+export const WithLabel: Story = WithLabelTemplate.bind({});
+WithLabel.args = {
+  selected: true
 };

--- a/libs/web-components/tsconfig.json
+++ b/libs/web-components/tsconfig.json
@@ -165,6 +165,9 @@
     },
     {
       "path": "alert-message"
+    },
+    {
+      "path": "formfield"
     }
   ]
 }


### PR DESCRIPTION
To be able to have labels next to checkbox, radio and switch :  

<img width="257" alt="Screenshot 2023-01-13 at 17 31 33" src="https://user-images.githubusercontent.com/62554667/212370908-e6593602-0b67-4921-af50-23e61a51fe63.png">
<img width="138" alt="Screenshot 2023-01-13 at 17 31 39" src="https://user-images.githubusercontent.com/62554667/212370914-5b42162d-c1de-4b0c-a97a-e62c8bbd289f.png">
<img width="87" alt="Screenshot 2023-01-13 at 17 31 42" src="https://user-images.githubusercontent.com/62554667/212370919-3e9c1b5b-44e9-4609-9b8d-971897921aa6.png">


```
<fds-formfield label="Accept terms and conditions">
    <fds-checkbox checked></fds-checkbox>
</fds-formfield>
```
