### PR TITLE
fix for empty value badge

### DIFF
--- a/packages/fds-components-web/badge/src/badge.ts
+++ b/packages/fds-components-web/badge/src/badge.ts
@@ -29,7 +29,9 @@ export class Badge extends LitElement {
       <div class="container">
         <slot></slot>
         <div class="badge" position=${this.position}>
-          <span class="badge-value ${this.color?.toLowerCase()}"> ${!this.type ? this.value : ''} </span>
+          <span class="badge-value ${this.color?.toLowerCase()} ${!this.type && !this.value.length ? 'empty' : null}">
+            ${!this.type ? this.value : ''}
+          </span>
         </div>
       </div>
     `;

--- a/packages/fds-components-web/badge/src/styles.scss
+++ b/packages/fds-components-web/badge/src/styles.scss
@@ -25,6 +25,10 @@
   @include fds.elevation(4);
 
   margin: 5px;
+
+  &.empty {
+    display: none;
+  }
 }
 
 .outlined {


### PR DESCRIPTION
When the badge is of type `none` and it doesn't have a value, there's the border shadow showing up:

![image](https://user-images.githubusercontent.com/14956052/234508279-6b429683-3ef6-4616-9ad8-534d383801ff.png)

This PR fixes that issue:
![image](https://user-images.githubusercontent.com/14956052/234508460-d61638b3-bdb0-4f54-a7c9-92c1504f037d.png)
