### PR TITLE
Theme: Support important flag in mixins

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["stylelint-config-standard", "stylelint-config-standard-scss", "stylelint-prettier/recommended"],
+  "extends": ["stylelint-config-standard", "stylelint-config-standard-scss", "stylelint-config-prettier"],
   "rules": {
     "selector-class-pattern": "^([a-z][a-z0-9]*)([-_]+[a-z0-9]+)*$",
     "no-descending-specificity": null

--- a/packages/fds-theme-web/color/_mixins.scss
+++ b/packages/fds-theme-web/color/_mixins.scss
@@ -57,12 +57,13 @@
 ///
 /// @example
 ///   .my-primary-container {
-///     @include fds.background(primary);
+///     @include fds.background(primary, $important: true);
 ///   }
 ///
 /// @param {String} $style - The name of the style to apply
-@mixin background($style) {
-  @include property(background, $style);
+/// @param {Boolean} $important - Flag this rule as !important
+@mixin background($style, $important: false) {
+  @include property(background, $style, $important);
 }
 
 /// Generates CSS to apply color to a text.
@@ -73,15 +74,16 @@
 ///   }
 ///
 /// @param {String} $style - The name of the style to apply
-@mixin color($style) {
-  $bg-color: map.get(light.$tokens, $style);
+/// @param {Boolean} $important - Flag this rule as !important
+@mixin color($style, $important: false) {
   @if string.index($style, 'gradient') == 1 {
-    background: var(--fds-#{$style}, #{$bg-color});
+    @include property(background, $style, $important);
+    
     background-clip: text;
     -webkit-background-clip: text; /* stylelint-disable-line */
     -webkit-text-fill-color: transparent;
   } @else {
-    color: var(--fds-#{$style}, #{$bg-color});
+    @include property(color, $style, $important);
   }
 }
 
@@ -93,8 +95,9 @@
 ///   }
 ///
 /// @param {String} $style - The name of the style to apply
-@mixin fill($style) {
-  @include property(fill, $style);
+/// @param {Boolean} $important - Flag this rule as !important
+@mixin fill($style, $important: false) {
+  @include property(fill, $style, $important);
 }
 
 /// Maps mdc's css properties to fds ones.
@@ -119,8 +122,11 @@
 ///   }
 ///
 /// @param {String} $style - The name of the style to apply
-@mixin property($property, $style) {
+/// @param {Boolean} $important - Flag this rule as !important
+@mixin property($property, $style, $important: false) {
   $variable: map.get(light.$tokens, $style);
+  $important-rule: if($important, ' !important', '');
 
-  #{$property}: var(--fds-#{$style}, #{$variable});
+  /* stylelint-disable-next-line function-whitespace-after */
+  #{$property}: var(--fds-#{$style}, #{$variable})#{$important-rule};
 }

--- a/packages/fds-theme-web/color/color.stories.mdx
+++ b/packages/fds-theme-web/color/color.stories.mdx
@@ -114,7 +114,7 @@ There are 4 use cases where you would use colors:
   @include fds.background(surface);
 
   &.title {
-    @include fds.color(primary);
+    @include fds.color(primary, $important: true);
   }
 
   &svg {
@@ -131,7 +131,7 @@ will generate:
 }
 
 .my-container.title {
-  color: var(--fds-primary, #694ed6);
+  color: var(--fds-primary, #694ed6) !important;
 }
 ```
 
@@ -145,7 +145,7 @@ If you want to use another property than those, you can use the generic `propert
 }
 
 .my-border {
-  @include fds.property(border-color, outline);
+  @include fds.property(border-color, outline, $important: true);
 }
 ```
 


### PR DESCRIPTION
## Usage
```SCSS
@include fds.background(primary, $important: true);
// OR
@include fds.background(primary, true);
```
will result in:
```SCSS
background: var(--fds-primary, #694ED6) !important;
```